### PR TITLE
Add manager approval flow for absence requests backend

### DIFF
--- a/backend/absence_manager_backend/Data/AbsenceManagerDbContext.cs
+++ b/backend/absence_manager_backend/Data/AbsenceManagerDbContext.cs
@@ -285,6 +285,9 @@ namespace Data
 
                 entity.HasIndex(x => new { x.UserId, x.DateFrom, x.DateTo, x.Status })
                     .HasDatabaseName("IX_AbsenceRequests_User_DateRange_Status");
+
+                entity.Property(x => x.DecisionComment)
+                    .HasMaxLength(1000);
             });
 
             // -------------------------

--- a/backend/absence_manager_backend/Data/Migrations/20260522110041_AddAbsenceRequestDecisionComment.Designer.cs
+++ b/backend/absence_manager_backend/Data/Migrations/20260522110041_AddAbsenceRequestDecisionComment.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Data.Migrations
 {
     [DbContext(typeof(AbsenceManagerDbContext))]
-    partial class AbsenceManagerDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260522110041_AddAbsenceRequestDecisionComment")]
+    partial class AddAbsenceRequestDecisionComment
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/absence_manager_backend/Data/Migrations/20260522110041_AddAbsenceRequestDecisionComment.cs
+++ b/backend/absence_manager_backend/Data/Migrations/20260522110041_AddAbsenceRequestDecisionComment.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddAbsenceRequestDecisionComment : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "DecisionComment",
+                table: "AbsenceRequests",
+                type: "character varying(1000)",
+                maxLength: 1000,
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "DecisionComment",
+                table: "AbsenceRequests");
+        }
+    }
+}

--- a/backend/absence_manager_backend/Entities/Dtos/AbsenceRequestDtos/AbsenceRequestApprovalDto.cs
+++ b/backend/absence_manager_backend/Entities/Dtos/AbsenceRequestDtos/AbsenceRequestApprovalDto.cs
@@ -1,0 +1,32 @@
+﻿using Entities.Enums;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Entities.Dtos.AbsenceRequestDtos
+{
+    public class AbsenceRequestApprovalDto
+    {
+        public string Id { get; set; } = null!;
+
+        public string UserId { get; set; } = null!;
+
+        public string? UserDisplayName { get; set; }
+
+        public string? UserEmail { get; set; }
+
+        public AbsenceRequestType Type { get; set; }
+
+        public AbsenceRequestStatus Status { get; set; }
+
+        public DateOnly DateFrom { get; set; }
+
+        public DateOnly DateTo { get; set; }
+
+        public string? Reason { get; set; }
+
+        public DateTime CreatedAtUtc { get; set; }
+
+        public string? DecisionComment { get; set; }
+    }
+}

--- a/backend/absence_manager_backend/Entities/Dtos/AbsenceRequestDtos/AbsenceRequestDecisionDto.cs
+++ b/backend/absence_manager_backend/Entities/Dtos/AbsenceRequestDtos/AbsenceRequestDecisionDto.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Entities.Dtos.AbsenceRequestDtos
+{
+    public class AbsenceRequestDecisionDto
+    {
+        public string? DecisionComment { get; set; }
+    }
+}

--- a/backend/absence_manager_backend/Entities/Dtos/AbsenceRequestDtos/AbsenceRequestViewDto.cs
+++ b/backend/absence_manager_backend/Entities/Dtos/AbsenceRequestDtos/AbsenceRequestViewDto.cs
@@ -25,5 +25,14 @@ namespace Entities.Dtos.AbsenceRequestDtos
         public string? Department { get; set; }
 
         public DateTime CreatedAtUtc { get; set; }
+        public DateTime? UpdatedAtUtc { get; set; }
+
+        public DateTime? ReviewedAtUtc { get; set; }
+
+        public string? ReviewedByUserId { get; set; }
+
+        public string? ReviewedByUserName { get; set; }
+
+        public string? DecisionComment { get; set; }
     }
 }

--- a/backend/absence_manager_backend/Entities/Models/AbsenceRequest.cs
+++ b/backend/absence_manager_backend/Entities/Models/AbsenceRequest.cs
@@ -28,6 +28,7 @@ namespace Entities.Models
         public DateOnly DateTo { get; set; }
 
         public string? Reason { get; set; }
+        public string? DecisionComment { get; set; }
 
         public DateTime CreatedAtUtc { get; set; }
 

--- a/backend/absence_manager_backend/Logic/Logic/AbsenceRequestLogic.cs
+++ b/backend/absence_manager_backend/Logic/Logic/AbsenceRequestLogic.cs
@@ -15,6 +15,42 @@ namespace Logic.Logic
             _dbContext = dbContext;
         }
 
+        public async Task<IReadOnlyList<AbsenceRequestViewDto>> GetMyAbsenceRequestsAsync(string currentUserId, CancellationToken cancellationToken = default)
+        {
+            if (string.IsNullOrWhiteSpace(currentUserId))
+            {
+                throw new ArgumentException("Current user id is required.", nameof(currentUserId));
+            }
+
+            return await _dbContext.AbsenceRequests
+                .AsNoTracking()
+                .Include(x => x.User)
+                .Include(x => x.ReviewedByUser)
+                .Where(x => x.UserId == currentUserId)
+                .OrderByDescending(x => x.CreatedAtUtc)
+                .Select(x => new AbsenceRequestViewDto
+                {
+                    Id = x.Id,
+                    Type = x.Type.ToString(),
+                    Status = x.Status.ToString(),
+                    DateFrom = x.DateFrom,
+                    DateTo = x.DateTo,
+                    Reason = x.Reason,
+                    UserId = x.UserId,
+                    UserName = x.User.DisplayName,
+                    Department = x.User.Department,
+                    CreatedAtUtc = x.CreatedAtUtc,
+                    UpdatedAtUtc = x.UpdatedAtUtc,
+                    ReviewedAtUtc = x.ReviewedAtUtc,
+                    ReviewedByUserId = x.ReviewedByUserId,
+                    ReviewedByUserName = x.ReviewedByUser != null
+                        ? x.ReviewedByUser.DisplayName
+                        : null,
+                    DecisionComment = x.DecisionComment
+                })
+                .ToListAsync(cancellationToken);
+        }
+
         public async Task ApproveAbsenceRequestAsync(string absenceRequestId, string managerUserId, string? decisionComment, CancellationToken cancellationToken = default)
         {
             await ReviewAbsenceRequestAsync(

--- a/backend/absence_manager_backend/Logic/Logic/AbsenceRequestLogic.cs
+++ b/backend/absence_manager_backend/Logic/Logic/AbsenceRequestLogic.cs
@@ -15,6 +15,50 @@ namespace Logic.Logic
             _dbContext = dbContext;
         }
 
+        public async Task<IReadOnlyList<AbsenceRequestApprovalDto>> GetPendingApprovalsForManagerAsync(string managerUserId, CancellationToken cancellationToken = default)
+        {
+            if (string.IsNullOrWhiteSpace(managerUserId))
+            {
+                throw new ArgumentException("Manager user id is required.", nameof(managerUserId));
+            }
+
+            var directReportUserIds = await _dbContext.AppUserManagerRelations
+                .AsNoTracking()
+                .Where(x => x.ManagerUserId == managerUserId && x.IsActive)
+                .Select(x => x.UserId)
+                .Distinct()
+                .ToListAsync(cancellationToken);
+
+            if (directReportUserIds.Count == 0)
+            {
+                return [];
+            }
+
+            return await _dbContext.AbsenceRequests
+                .AsNoTracking()
+                .Include(x => x.User)
+                .Where(x =>
+                    directReportUserIds.Contains(x.UserId) &&
+                    x.Status == AbsenceRequestStatus.Pending)
+                .OrderBy(x => x.DateFrom)
+                .ThenBy(x => x.CreatedAtUtc)
+                .Select(x => new AbsenceRequestApprovalDto
+                {
+                    Id = x.Id,
+                    UserId = x.UserId,
+                    UserDisplayName = x.User.DisplayName,
+                    UserEmail = x.User.Email,
+                    Type = x.Type,
+                    Status = x.Status,
+                    DateFrom = x.DateFrom,
+                    DateTo = x.DateTo,
+                    Reason = x.Reason,
+                    CreatedAtUtc = x.CreatedAtUtc,
+                    DecisionComment = x.DecisionComment
+                })
+                .ToListAsync(cancellationToken);
+        }
+
         public async Task<AbsenceRequestViewDto> CreateAsync(
             CreateAbsenceRequestDto dto,
             string currentUserId,

--- a/backend/absence_manager_backend/Logic/Logic/AbsenceRequestLogic.cs
+++ b/backend/absence_manager_backend/Logic/Logic/AbsenceRequestLogic.cs
@@ -15,6 +15,26 @@ namespace Logic.Logic
             _dbContext = dbContext;
         }
 
+        public async Task ApproveAbsenceRequestAsync(string absenceRequestId, string managerUserId, string? decisionComment, CancellationToken cancellationToken = default)
+        {
+            await ReviewAbsenceRequestAsync(
+                absenceRequestId,
+                managerUserId,
+                AbsenceRequestStatus.Approved,
+                decisionComment,
+                cancellationToken);
+        }
+
+        public async Task RejectAbsenceRequestAsync(string absenceRequestId, string managerUserId, string? decisionComment, CancellationToken cancellationToken = default)
+        {
+            await ReviewAbsenceRequestAsync(
+                absenceRequestId,
+                managerUserId,
+                AbsenceRequestStatus.Rejected,
+                decisionComment,
+                cancellationToken);
+        }
+
         public async Task<IReadOnlyList<AbsenceRequestApprovalDto>> GetPendingApprovalsForManagerAsync(string managerUserId, CancellationToken cancellationToken = default)
         {
             if (string.IsNullOrWhiteSpace(managerUserId))
@@ -148,10 +168,7 @@ namespace Logic.Logic
             return ToViewDto(request);
         }
 
-        public async Task CancelAsync(
-            string id,
-            string currentUserId,
-            CancellationToken cancellationToken = default)
+        public async Task CancelAsync(string id, string currentUserId, CancellationToken cancellationToken = default)
         {
             var request = await _dbContext.AbsenceRequests
                 .FirstOrDefaultAsync(x => x.Id == id, cancellationToken)
@@ -278,6 +295,63 @@ namespace Logic.Logic
                 || title.Contains("admin", StringComparison.OrdinalIgnoreCase)
                 || title.Contains("administrator", StringComparison.OrdinalIgnoreCase)
                 || title.Contains("people", StringComparison.OrdinalIgnoreCase);
+        }
+
+        private async Task ReviewAbsenceRequestAsync(string absenceRequestId, string managerUserId, AbsenceRequestStatus targetStatus, string? decisionComment, CancellationToken cancellationToken)
+        {
+            if (string.IsNullOrWhiteSpace(absenceRequestId))
+            {
+                throw new ArgumentException("Absence request id is required.", nameof(absenceRequestId));
+            }
+
+            if (string.IsNullOrWhiteSpace(managerUserId))
+            {
+                throw new ArgumentException("Manager user id is required.", nameof(managerUserId));
+            }
+
+            if (targetStatus != AbsenceRequestStatus.Approved &&
+                targetStatus != AbsenceRequestStatus.Rejected)
+            {
+                throw new ArgumentException("Target status must be Approved or Rejected.", nameof(targetStatus));
+            }
+
+            var absenceRequest = await _dbContext.AbsenceRequests
+                .FirstOrDefaultAsync(x => x.Id == absenceRequestId, cancellationToken);
+
+            if (absenceRequest == null)
+            {
+                throw new KeyNotFoundException("Absence request was not found.");
+            }
+
+            if (absenceRequest.Status != AbsenceRequestStatus.Pending)
+            {
+                throw new InvalidOperationException("Only pending absence requests can be reviewed.");
+            }
+
+            var isActiveManager = await _dbContext.AppUserManagerRelations
+                .AsNoTracking()
+                .AnyAsync(x =>
+                    x.UserId == absenceRequest.UserId &&
+                    x.ManagerUserId == managerUserId &&
+                    x.IsActive,
+                    cancellationToken);
+
+            if (!isActiveManager)
+            {
+                throw new UnauthorizedAccessException("You are not allowed to review this absence request.");
+            }
+
+            var now = DateTime.UtcNow;
+
+            absenceRequest.Status = targetStatus;
+            absenceRequest.ReviewedByUserId = managerUserId;
+            absenceRequest.ReviewedAtUtc = now;
+            absenceRequest.UpdatedAtUtc = now;
+            absenceRequest.DecisionComment = string.IsNullOrWhiteSpace(decisionComment)
+                ? null
+                : decisionComment.Trim();
+
+            await _dbContext.SaveChangesAsync(cancellationToken);
         }
     }
 }

--- a/backend/absence_manager_backend/Logic/Logic/AbsenceRequestLogic.cs
+++ b/backend/absence_manager_backend/Logic/Logic/AbsenceRequestLogic.cs
@@ -15,42 +15,6 @@ namespace Logic.Logic
             _dbContext = dbContext;
         }
 
-        public async Task<IReadOnlyList<AbsenceRequestViewDto>> GetMyAbsenceRequestsAsync(string currentUserId, CancellationToken cancellationToken = default)
-        {
-            if (string.IsNullOrWhiteSpace(currentUserId))
-            {
-                throw new ArgumentException("Current user id is required.", nameof(currentUserId));
-            }
-
-            return await _dbContext.AbsenceRequests
-                .AsNoTracking()
-                .Include(x => x.User)
-                .Include(x => x.ReviewedByUser)
-                .Where(x => x.UserId == currentUserId)
-                .OrderByDescending(x => x.CreatedAtUtc)
-                .Select(x => new AbsenceRequestViewDto
-                {
-                    Id = x.Id,
-                    Type = x.Type.ToString(),
-                    Status = x.Status.ToString(),
-                    DateFrom = x.DateFrom,
-                    DateTo = x.DateTo,
-                    Reason = x.Reason,
-                    UserId = x.UserId,
-                    UserName = x.User.DisplayName,
-                    Department = x.User.Department,
-                    CreatedAtUtc = x.CreatedAtUtc,
-                    UpdatedAtUtc = x.UpdatedAtUtc,
-                    ReviewedAtUtc = x.ReviewedAtUtc,
-                    ReviewedByUserId = x.ReviewedByUserId,
-                    ReviewedByUserName = x.ReviewedByUser != null
-                        ? x.ReviewedByUser.DisplayName
-                        : null,
-                    DecisionComment = x.DecisionComment
-                })
-                .ToListAsync(cancellationToken);
-        }
-
         public async Task ApproveAbsenceRequestAsync(string absenceRequestId, string managerUserId, string? decisionComment, CancellationToken cancellationToken = default)
         {
             await ReviewAbsenceRequestAsync(
@@ -282,20 +246,26 @@ namespace Logic.Logic
             };
         }
 
-        public static AbsenceRequestViewDto ToViewDto(AbsenceRequest request)
+        private static AbsenceRequestViewDto ToViewDto(AbsenceRequest request)
         {
             return new AbsenceRequestViewDto
             {
                 Id = request.Id,
-                Type = ToTypeKey(request.Type),
-                Status = ToStatusKey(request.Status),
+                Type = request.Type.ToString(),
+                Status = request.Status.ToString(),
                 DateFrom = request.DateFrom,
                 DateTo = request.DateTo,
                 Reason = request.Reason,
                 UserId = request.UserId,
                 UserName = request.User.DisplayName,
                 Department = request.User.Department,
-                CreatedAtUtc = request.CreatedAtUtc
+                CreatedAtUtc = request.CreatedAtUtc,
+
+                UpdatedAtUtc = request.UpdatedAtUtc,
+                ReviewedAtUtc = request.ReviewedAtUtc,
+                ReviewedByUserId = request.ReviewedByUserId,
+                ReviewedByUserName = request.ReviewedByUser?.DisplayName,
+                DecisionComment = request.DecisionComment
             };
         }
 

--- a/backend/absence_manager_backend/absence_manager_backend/Controllers/AbsenceRequestsController.cs
+++ b/backend/absence_manager_backend/absence_manager_backend/Controllers/AbsenceRequestsController.cs
@@ -116,5 +116,28 @@ namespace Absence_Manager.Controllers
                 return NotFound(new { message = ex.Message });
             }
         }
+
+        [HttpGet("pending-approvals")]
+        public async Task<IActionResult> GetPendingApprovals(CancellationToken cancellationToken)
+        {
+            try
+            {
+                var currentUserId = await _currentUserService.GetUserIdAsync(cancellationToken);
+
+                var pendingApprovals = await _absenceRequestLogic.GetPendingApprovalsForManagerAsync(
+                    currentUserId,
+                    cancellationToken);
+
+                return Ok(pendingApprovals);
+            }
+            catch (UnauthorizedAccessException ex)
+            {
+                return Unauthorized(new { message = ex.Message });
+            }
+            catch (KeyNotFoundException ex)
+            {
+                return NotFound(new { message = ex.Message });
+            }
+        }
     }
 }

--- a/backend/absence_manager_backend/absence_manager_backend/Controllers/AbsenceRequestsController.cs
+++ b/backend/absence_manager_backend/absence_manager_backend/Controllers/AbsenceRequestsController.cs
@@ -93,9 +93,7 @@ namespace Absence_Manager.Controllers
         }
 
         [HttpDelete("{id}")]
-        public async Task<IActionResult> Cancel(
-            string id,
-            CancellationToken cancellationToken)
+        public async Task<IActionResult> Cancel(string id, CancellationToken cancellationToken)
         {
             try
             {
@@ -137,6 +135,72 @@ namespace Absence_Manager.Controllers
             catch (KeyNotFoundException ex)
             {
                 return NotFound(new { message = ex.Message });
+            }
+        }
+
+        [HttpPost("{id}/approve")]
+        public async Task<IActionResult> ApproveAbsenceRequest(string id, [FromBody] AbsenceRequestDecisionDto? decision, CancellationToken cancellationToken)
+        {
+            try
+            {
+                var currentUserId = await _currentUserService.GetUserIdAsync(cancellationToken);
+
+                await _absenceRequestLogic.ApproveAbsenceRequestAsync(
+                    id,
+                    currentUserId,
+                    decision?.DecisionComment,
+                    cancellationToken);
+
+                return NoContent();
+            }
+            catch (UnauthorizedAccessException ex)
+            {
+                return Forbid();
+            }
+            catch (KeyNotFoundException ex)
+            {
+                return NotFound(new { message = ex.Message });
+            }
+            catch (InvalidOperationException ex)
+            {
+                return BadRequest(new { message = ex.Message });
+            }
+            catch (ArgumentException ex)
+            {
+                return BadRequest(new { message = ex.Message });
+            }
+        }
+
+        [HttpPost("{id}/reject")]
+        public async Task<IActionResult> RejectAbsenceRequest(string id, [FromBody] AbsenceRequestDecisionDto? decision, CancellationToken cancellationToken)
+        {
+            try
+            {
+                var currentUserId = await _currentUserService.GetUserIdAsync(cancellationToken);
+
+                await _absenceRequestLogic.RejectAbsenceRequestAsync(
+                    id,
+                    currentUserId,
+                    decision?.DecisionComment,
+                    cancellationToken);
+
+                return NoContent();
+            }
+            catch (UnauthorizedAccessException)
+            {
+                return Forbid();
+            }
+            catch (KeyNotFoundException ex)
+            {
+                return NotFound(new { message = ex.Message });
+            }
+            catch (InvalidOperationException ex)
+            {
+                return BadRequest(new { message = ex.Message });
+            }
+            catch (ArgumentException ex)
+            {
+                return BadRequest(new { message = ex.Message });
             }
         }
     }

--- a/backend/absence_manager_backend/absence_manager_backend/Controllers/AbsenceRequestsController.cs
+++ b/backend/absence_manager_backend/absence_manager_backend/Controllers/AbsenceRequestsController.cs
@@ -203,5 +203,24 @@ namespace Absence_Manager.Controllers
                 return BadRequest(new { message = ex.Message });
             }
         }
+
+        [HttpGet("my")]
+        public async Task<IActionResult> GetMyAbsenceRequests(CancellationToken cancellationToken)
+        {
+            try
+            {
+                var currentUserId = await _currentUserService.GetUserIdAsync(cancellationToken);
+
+                var requests = await _absenceRequestLogic.GetMyAbsenceRequestsAsync(
+                    currentUserId,
+                    cancellationToken);
+
+                return Ok(requests);
+            }
+            catch (UnauthorizedAccessException ex)
+            {
+                return Unauthorized(new { message = ex.Message });
+            }
+        }
     }
 }

--- a/backend/absence_manager_backend/absence_manager_backend/Controllers/AbsenceRequestsController.cs
+++ b/backend/absence_manager_backend/absence_manager_backend/Controllers/AbsenceRequestsController.cs
@@ -203,24 +203,5 @@ namespace Absence_Manager.Controllers
                 return BadRequest(new { message = ex.Message });
             }
         }
-
-        [HttpGet("my")]
-        public async Task<IActionResult> GetMyAbsenceRequests(CancellationToken cancellationToken)
-        {
-            try
-            {
-                var currentUserId = await _currentUserService.GetUserIdAsync(cancellationToken);
-
-                var requests = await _absenceRequestLogic.GetMyAbsenceRequestsAsync(
-                    currentUserId,
-                    cancellationToken);
-
-                return Ok(requests);
-            }
-            catch (UnauthorizedAccessException ex)
-            {
-                return Unauthorized(new { message = ex.Message });
-            }
-        }
     }
 }


### PR DESCRIPTION
# PR description

## Description

This PR adds a manager-based approval flow for absence requests.

The implementation builds on the previously added manager hierarchy synchronization, where Microsoft Graph based user-manager relationships are stored locally in the `AppUserManagerRelations` table. The approval flow uses this local relation table for authorization checks.

## Changes

- Added an optional decision comment field to absence requests.
- Added a migration for the new `DecisionComment` field.
- Added a manager pending approvals query.
- Added a new endpoint for managers to list requests waiting for their approval:
  - `GET /api/absence-requests/pending-approvals`
- Added approve and reject business logic.
- Added new decision endpoints:
  - `POST /api/absence-requests/{id}/approve`
  - `POST /api/absence-requests/{id}/reject`
- Added manager authorization checks based on `AppUserManagerRelations`.
- Extended the existing own absence requests query with review data:
  - `ReviewedAtUtc`
  - `ReviewedByUserId`
  - `ReviewedByUserName`
  - `DecisionComment`

## Expected behavior

New absence requests continue to be created with `Pending` status.

A manager can list pending requests from their active direct reports. The system only returns requests where the current user is stored as the active manager in the `AppUserManagerRelations` table.

A manager can approve or reject a `Pending` request. When a decision is made, the system stores:

- the new status,
- the local user id of the manager who made the decision,
- the decision timestamp,
- the optional decision comment.

If the current user is not the active manager of the request owner, approval or rejection is not allowed.

## Testing

- Backend build completed successfully.
- Swagger loads successfully.
- Database migration completed successfully.
- The `DecisionComment` column was created in the database.
- The pending approvals endpoint works.
- The approve endpoint works with the POST method.
- The reject endpoint is available.
- Verified with local test data that a manager can only see and approve requests from active direct reports.
- The own absence requests endpoint returns the review fields.

## Note

The frontend approval UI is not included in this PR. It should be handled in a separate issue.
