### PR TITLE
MS Graph user szinkron egységesítése

### DIFF
--- a/backend/absence_manager_backend/Entities/Dtos/AppUserDtos/UserContextDto.cs
+++ b/backend/absence_manager_backend/Entities/Dtos/AppUserDtos/UserContextDto.cs
@@ -1,0 +1,20 @@
+﻿using Entities.Dtos.Graph;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Entities.Dtos.AppUserDtos
+{
+    public class UserContextDto
+    {
+        public UserProfileDto Profile { get; set; } = null!;
+
+        public AppUserHierarchyDto Hierarchy { get; set; } = new();
+
+        public bool IsManager { get; set; }
+
+        public IReadOnlyList<string> Roles { get; set; } = Array.Empty<string>();
+
+        public DateTime? LastGraphSyncAtUtc { get; set; }
+    }
+}

--- a/backend/absence_manager_backend/Entities/Entities.csproj
+++ b/backend/absence_manager_backend/Entities/Entities.csproj
@@ -11,8 +11,4 @@
 		<PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="10.0.5" />
 	</ItemGroup>
 
-	<ItemGroup>
-	  <Folder Include="Dtos\AppUserDtos\" />
-	</ItemGroup>
-
 </Project>

--- a/backend/absence_manager_backend/Logic/Logic/CurrentUserGraphSyncService.cs
+++ b/backend/absence_manager_backend/Logic/Logic/CurrentUserGraphSyncService.cs
@@ -11,9 +11,9 @@ namespace Logic.Logic
     }
     public class CurrentUserGraphSyncService : ICurrentUserGraphSyncService
     {
-        private readonly UserLogic _userLogic;
+        private readonly IUserLogic _userLogic;
 
-        public CurrentUserGraphSyncService(UserLogic userLogic)
+        public CurrentUserGraphSyncService(IUserLogic userLogic)
         {
             _userLogic = userLogic;
         }

--- a/backend/absence_manager_backend/Logic/Logic/CurrentUserGraphSyncService.cs
+++ b/backend/absence_manager_backend/Logic/Logic/CurrentUserGraphSyncService.cs
@@ -1,0 +1,50 @@
+﻿using Entities.Dtos.AppUserDtos;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Logic.Logic
+{
+    public interface ICurrentUserGraphSyncService
+    {
+        Task<UserContextDto> SyncCurrentUserFromGraphAsync(string currentUserId, CancellationToken cancellationToken = default);
+    }
+    public class CurrentUserGraphSyncService : ICurrentUserGraphSyncService
+    {
+        private readonly UserLogic _userLogic;
+
+        public CurrentUserGraphSyncService(UserLogic userLogic)
+        {
+            _userLogic = userLogic;
+        }
+
+        public async Task<UserContextDto> SyncCurrentUserFromGraphAsync(string currentUserId, CancellationToken cancellationToken = default)
+        {
+            if (string.IsNullOrWhiteSpace(currentUserId))
+            {
+                throw new ArgumentException("Current user id is required.", nameof(currentUserId));
+            }
+
+            await _userLogic.RefreshUserProfileAsync(currentUserId, cancellationToken);
+
+            var hierarchy = await _userLogic.GetCurrentUserHierarchyAsync(
+                currentUserId,
+                cancellationToken);
+
+            var profile = _userLogic.GetUserProfile(currentUserId);
+
+            var isManager = hierarchy.DirectReports.Any();
+
+            return new UserContextDto
+            {
+                Profile = profile,
+                Hierarchy = hierarchy,
+                IsManager = isManager,
+                Roles = isManager
+                    ? new[] { "Manager" }
+                    : Array.Empty<string>(),
+                LastGraphSyncAtUtc = DateTime.UtcNow
+            };
+        }
+    }
+}

--- a/backend/absence_manager_backend/Logic/Logic/CurrentUserGraphSyncService.cs
+++ b/backend/absence_manager_backend/Logic/Logic/CurrentUserGraphSyncService.cs
@@ -27,7 +27,7 @@ namespace Logic.Logic
 
             await _userLogic.RefreshUserProfileAsync(currentUserId, cancellationToken);
 
-            var hierarchy = await _userLogic.GetCurrentUserHierarchyAsync(
+            var hierarchy = await _userLogic.SyncCurrentUserHierarchyFromGraphAsync(
                 currentUserId,
                 cancellationToken);
 

--- a/backend/absence_manager_backend/Logic/Logic/UserLogic.cs
+++ b/backend/absence_manager_backend/Logic/Logic/UserLogic.cs
@@ -81,8 +81,9 @@ namespace Logic.Logic
 
             graphUsers.AddRange(graphHierarchy.DirectReports);
 
-            var localUsersByEntraObjectId = await GetLocalUsersByEntraObjectIdAsync(
+            var localUsersByEntraObjectId = await EnsureGraphUsersExistAsync(
                 graphUsers,
+                currentUser.TenantId,
                 cancellationToken);
 
             await SyncHierarchyRelationsAsync(
@@ -398,6 +399,134 @@ namespace Logic.Logic
                 IsKnownLocalUser = false,
                 IsActiveLocalUser = false
             };
+        }
+
+        private async Task<Dictionary<string, AppUser>> EnsureGraphUsersExistAsync(IEnumerable<GraphUserDto> graphUsers, string? tenantId, CancellationToken cancellationToken)
+        {
+            var uniqueGraphUsers = graphUsers
+                .Where(x => !string.IsNullOrWhiteSpace(x.EntraObjectId))
+                .GroupBy(x => x.EntraObjectId)
+                .Select(x => x.First())
+                .ToList();
+
+            if (uniqueGraphUsers.Count == 0)
+            {
+                return new Dictionary<string, AppUser>();
+            }
+
+            var entraObjectIds = uniqueGraphUsers
+                .Select(x => x.EntraObjectId)
+                .Distinct()
+                .ToList();
+
+            var localUsers = await _dbContext.AppUsers
+                .Where(x =>
+                    entraObjectIds.Contains(x.EntraObjectId) &&
+                    x.TenantId == tenantId)
+                .ToListAsync(cancellationToken);
+
+            var localUsersByEntraObjectId = localUsers
+                .GroupBy(x => x.EntraObjectId)
+                .ToDictionary(x => x.Key, x => x.First());
+
+            foreach (var graphUser in uniqueGraphUsers)
+            {
+                if (localUsersByEntraObjectId.TryGetValue(graphUser.EntraObjectId, out var localUser))
+                {
+                    ApplyGraphUserData(localUser, graphUser);
+                    continue;
+                }
+
+                var newUser = CreateAppUserFromGraphUser(graphUser, tenantId);
+
+                _dbContext.AppUsers.Add(newUser);
+                localUsersByEntraObjectId[newUser.EntraObjectId] = newUser;
+            }
+
+            await _dbContext.SaveChangesAsync(cancellationToken);
+
+            return localUsersByEntraObjectId;
+        }
+
+        private static void ApplyGraphUserData(AppUser user, GraphUserDto graphUser)
+        {
+            var displayName = GetGraphDisplayName(graphUser);
+            var email = GetGraphEmail(graphUser);
+
+            if (!string.IsNullOrWhiteSpace(displayName) && user.DisplayName != displayName)
+            {
+                user.DisplayName = displayName;
+            }
+
+            if (!string.IsNullOrWhiteSpace(email) && user.Email != email)
+            {
+                user.Email = email;
+            }
+
+            if (graphUser.Department != null && user.Department != graphUser.Department)
+            {
+                user.Department = graphUser.Department;
+            }
+
+            if (graphUser.JobTitle != null && user.JobTitle != graphUser.JobTitle)
+            {
+                user.JobTitle = graphUser.JobTitle;
+            }
+
+            if (!user.IsActive)
+            {
+                user.IsActive = true;
+            }
+        }
+
+        private static AppUser CreateAppUserFromGraphUser(GraphUserDto graphUser, string? tenantId)
+        {
+            return new AppUser
+            {
+                EntraObjectId = graphUser.EntraObjectId,
+                TenantId = tenantId,
+                DisplayName = GetGraphDisplayName(graphUser),
+                Email = GetGraphEmail(graphUser),
+                Department = graphUser.Department ?? string.Empty,
+                JobTitle = graphUser.JobTitle ?? string.Empty,
+                IsActive = true,
+                CreatedAt = DateTime.UtcNow
+            };
+        }
+
+        private static string GetGraphDisplayName(GraphUserDto graphUser)
+        {
+            if (!string.IsNullOrWhiteSpace(graphUser.DisplayName))
+            {
+                return graphUser.DisplayName;
+            }
+
+            if (!string.IsNullOrWhiteSpace(graphUser.UserPrincipalName))
+            {
+                return graphUser.UserPrincipalName;
+            }
+
+            if (!string.IsNullOrWhiteSpace(graphUser.Email))
+            {
+                return graphUser.Email;
+            }
+
+            return graphUser.EntraObjectId;
+        }
+
+        private static string? GetGraphEmail(GraphUserDto graphUser)
+        {
+            if (!string.IsNullOrWhiteSpace(graphUser.Email))
+            {
+                return graphUser.Email;
+            }
+
+            if (!string.IsNullOrWhiteSpace(graphUser.UserPrincipalName))
+            {
+                return graphUser.UserPrincipalName;
+            }
+
+            return null;
         }
     }
 }

--- a/backend/absence_manager_backend/Logic/Logic/UserLogic.cs
+++ b/backend/absence_manager_backend/Logic/Logic/UserLogic.cs
@@ -88,15 +88,66 @@ namespace Logic.Logic
             };
         }
 
+        public Task<AppUserHierarchyDto> SyncCurrentUserHierarchyFromGraphAsync(string currentUserId, CancellationToken cancellationToken = default)
+        {
+            return GetCurrentUserHierarchyAsync(currentUserId, cancellationToken);
+        }
+
+        public async Task<AppUserHierarchyDto> GetCurrentUserHierarchyFromLocalDbAsync(string currentUserId, CancellationToken cancellationToken = default)
+        {
+            if (string.IsNullOrWhiteSpace(currentUserId))
+                throw new ArgumentException("Current user id is required.", nameof(currentUserId));
+
+            var currentUser = await _dbContext.AppUsers
+                .AsNoTracking()
+                .FirstOrDefaultAsync(x => x.Id == currentUserId, cancellationToken)
+                ?? throw new KeyNotFoundException("User not found.");
+
+            if (!currentUser.IsActive)
+                throw new InvalidOperationException("User is not active.");
+
+            var managerRelation = await _dbContext.AppUserManagerRelations
+                .AsNoTracking()
+                .Include(x => x.ManagerUser)
+                .FirstOrDefaultAsync(x =>
+                    x.UserId == currentUserId &&
+                    x.IsActive,
+                    cancellationToken);
+
+            var directReportRelations = await _dbContext.AppUserManagerRelations
+                .AsNoTracking()
+                .Include(x => x.User)
+                .Where(x =>
+                    x.ManagerUserId == currentUserId &&
+                    x.IsActive)
+                .ToListAsync(cancellationToken);
+
+            return new AppUserHierarchyDto
+            {
+                CurrentUser = ToGraphAppUserDto(currentUser),
+                Manager = ToManagerGraphAppUserDto(managerRelation),
+                DirectReports = directReportRelations
+                    .Where(x => x.User != null && x.User.IsActive)
+                    .Select(x => ToGraphAppUserDto(x.User))
+                    .ToList()
+            };
+        }
+
         public async Task<GraphAppUserDto?> GetCurrentUserManagerAsync(string currentUserId, CancellationToken cancellationToken = default)
         {
-            var hierarchy = await GetCurrentUserHierarchyAsync(currentUserId, cancellationToken);
+            var hierarchy = await GetCurrentUserHierarchyFromLocalDbAsync(
+                currentUserId,
+                cancellationToken);
+
             return hierarchy.Manager;
         }
 
         public async Task<IReadOnlyList<GraphAppUserDto>> GetCurrentUserDirectReportsAsync(string currentUserId, CancellationToken cancellationToken = default)
         {
-            var hierarchy = await GetCurrentUserHierarchyAsync(currentUserId, cancellationToken);
+            var hierarchy = await GetCurrentUserHierarchyFromLocalDbAsync(
+                currentUserId,
+                cancellationToken);
+
             return hierarchy.DirectReports;
         }
 
@@ -289,6 +340,49 @@ namespace Logic.Logic
         private static bool SameNullable(string? left, string? right)
         {
             return string.Equals(left, right, StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static GraphAppUserDto ToGraphAppUserDto(AppUser user)
+        {
+            return new GraphAppUserDto
+            {
+                EntraObjectId = user.EntraObjectId,
+                AppUserId = user.Id,
+                DisplayName = user.DisplayName,
+                Email = user.Email,
+                UserPrincipalName = user.Email,
+                Department = user.Department,
+                JobTitle = user.JobTitle,
+                OfficeLocation = null,
+                IsKnownLocalUser = true,
+                IsActiveLocalUser = user.IsActive
+            };
+        }
+
+        private static GraphAppUserDto? ToManagerGraphAppUserDto(AppUserManagerRelation? relation)
+        {
+            if (relation == null)
+                return null;
+
+            if (relation.ManagerUser != null)
+                return ToGraphAppUserDto(relation.ManagerUser);
+
+            if (string.IsNullOrWhiteSpace(relation.ManagerEntraObjectId))
+                return null;
+
+            return new GraphAppUserDto
+            {
+                EntraObjectId = relation.ManagerEntraObjectId,
+                AppUserId = null,
+                DisplayName = null,
+                Email = null,
+                UserPrincipalName = null,
+                Department = null,
+                JobTitle = null,
+                OfficeLocation = null,
+                IsKnownLocalUser = false,
+                IsActiveLocalUser = false
+            };
         }
     }
 }

--- a/backend/absence_manager_backend/Logic/Logic/UserLogic.cs
+++ b/backend/absence_manager_backend/Logic/Logic/UserLogic.cs
@@ -8,7 +8,22 @@ using Microsoft.EntityFrameworkCore;
 
 namespace Logic.Logic
 {
-    public class UserLogic
+    public interface IUserLogic
+    {
+        UserProfileDto GetUserProfile(string userId);
+
+        Task<AppUserHierarchyDto> SyncCurrentUserHierarchyFromGraphAsync(string currentUserId, CancellationToken cancellationToken = default);
+
+        Task<AppUserHierarchyDto> GetCurrentUserHierarchyFromLocalDbAsync(string currentUserId, CancellationToken cancellationToken = default);
+
+        Task<GraphAppUserDto?> GetCurrentUserManagerAsync(string currentUserId, CancellationToken cancellationToken = default);
+
+        Task<IReadOnlyList<GraphAppUserDto>> GetCurrentUserDirectReportsAsync(string currentUserId, CancellationToken cancellationToken = default);
+
+        Task RefreshUserProfileAsync(string userId, CancellationToken cancellationToken);
+    }
+
+    public class UserLogic : IUserLogic
     {
         private readonly Repository<AppUser> _userRepository;
         private readonly DtoProvider _dtoProvider;

--- a/backend/absence_manager_backend/absence_manager_backend/Controllers/UsersController.cs
+++ b/backend/absence_manager_backend/absence_manager_backend/Controllers/UsersController.cs
@@ -100,7 +100,9 @@ namespace Absence_Manager.Controllers
             try
             {
                 var currentUserId = await _currentUserService.GetUserIdAsync(cancellationToken);
-                var result = await _userLogic.GetCurrentUserHierarchyAsync(currentUserId, cancellationToken);
+                var result = await _userLogic.GetCurrentUserHierarchyFromLocalDbAsync(
+                    currentUserId,
+                    cancellationToken);
 
                 return Ok(result);
             }

--- a/backend/absence_manager_backend/absence_manager_backend/Controllers/UsersController.cs
+++ b/backend/absence_manager_backend/absence_manager_backend/Controllers/UsersController.cs
@@ -12,11 +12,11 @@ namespace Absence_Manager.Controllers
     [RequiredScope("user_impersonation")]
     public class UsersController : ControllerBase
     {
-        private readonly UserLogic _userLogic;
+        private readonly IUserLogic _userLogic;
         private readonly ICurrentUserService _currentUserService;
         private readonly ICurrentUserGraphSyncService _currentUserGraphSyncService;
 
-        public UsersController(UserLogic userLogic, ICurrentUserService currentUserService, ICurrentUserGraphSyncService currentUserGraphSyncService)
+        public UsersController(IUserLogic userLogic, ICurrentUserService currentUserService, ICurrentUserGraphSyncService currentUserGraphSyncService)
         {
             _userLogic = userLogic;
             _currentUserService = currentUserService;

--- a/backend/absence_manager_backend/absence_manager_backend/Controllers/UsersController.cs
+++ b/backend/absence_manager_backend/absence_manager_backend/Controllers/UsersController.cs
@@ -120,33 +120,33 @@ namespace Absence_Manager.Controllers
             }
         }
 
-        [HttpPost("me/sync-graph-profile")]
-        public async Task<IActionResult> SyncMyGraphProfile(CancellationToken cancellationToken)
-        {
-            try
-            {
-                var currentUserId = await _currentUserService.GetUserIdAsync(cancellationToken);
-                await _userLogic.RefreshUserProfileAsync(currentUserId, cancellationToken);
+        //[HttpPost("me/sync-graph-profile")]
+        //public async Task<IActionResult> SyncMyGraphProfile(CancellationToken cancellationToken)
+        //{
+        //    try
+        //    {
+        //        var currentUserId = await _currentUserService.GetUserIdAsync(cancellationToken);
+        //        await _userLogic.RefreshUserProfileAsync(currentUserId, cancellationToken);
 
-                return NoContent();
-            }
-            catch (OperationCanceledException)
-            {
-                return StatusCode(499, new { message = "A kérés megszakadt." });
-            }
-            catch (UnauthorizedAccessException ex)
-            {
-                return Unauthorized(new { message = ex.Message });
-            }
-            catch (KeyNotFoundException ex)
-            {
-                return NotFound(new { message = ex.Message });
-            }
-            catch (InvalidOperationException ex)
-            {
-                return BadRequest(new { message = ex.Message });
-            }
-        }
+        //        return NoContent();
+        //    }
+        //    catch (OperationCanceledException)
+        //    {
+        //        return StatusCode(499, new { message = "A kérés megszakadt." });
+        //    }
+        //    catch (UnauthorizedAccessException ex)
+        //    {
+        //        return Unauthorized(new { message = ex.Message });
+        //    }
+        //    catch (KeyNotFoundException ex)
+        //    {
+        //        return NotFound(new { message = ex.Message });
+        //    }
+        //    catch (InvalidOperationException ex)
+        //    {
+        //        return BadRequest(new { message = ex.Message });
+        //    }
+        //}
 
         [HttpPost("me/sync-from-graph")]
         public async Task<IActionResult> SyncCurrentUserFromGraph(CancellationToken cancellationToken)

--- a/backend/absence_manager_backend/absence_manager_backend/Controllers/UsersController.cs
+++ b/backend/absence_manager_backend/absence_manager_backend/Controllers/UsersController.cs
@@ -14,11 +14,13 @@ namespace Absence_Manager.Controllers
     {
         private readonly UserLogic _userLogic;
         private readonly ICurrentUserService _currentUserService;
+        private readonly ICurrentUserGraphSyncService _currentUserGraphSyncService;
 
-        public UsersController(UserLogic userLogic, ICurrentUserService currentUserService)
+        public UsersController(UserLogic userLogic, ICurrentUserService currentUserService, ICurrentUserGraphSyncService currentUserGraphSyncService)
         {
             _userLogic = userLogic;
             _currentUserService = currentUserService;
+            _currentUserGraphSyncService = currentUserGraphSyncService;
         }
 
         [HttpGet("me")]
@@ -139,6 +141,41 @@ namespace Absence_Manager.Controllers
                 return NotFound(new { message = ex.Message });
             }
             catch (InvalidOperationException ex)
+            {
+                return BadRequest(new { message = ex.Message });
+            }
+        }
+
+        [HttpPost("me/sync-from-graph")]
+        public async Task<IActionResult> SyncCurrentUserFromGraph(CancellationToken cancellationToken)
+        {
+            try
+            {
+                var currentUserId = await _currentUserService.GetUserIdAsync(cancellationToken);
+
+                var result = await _currentUserGraphSyncService.SyncCurrentUserFromGraphAsync(
+                    currentUserId,
+                    cancellationToken);
+
+                return Ok(result);
+            }
+            catch (OperationCanceledException)
+            {
+                return StatusCode(499, new { message = "A kérés megszakadt." });
+            }
+            catch (UnauthorizedAccessException ex)
+            {
+                return Unauthorized(new { message = ex.Message });
+            }
+            catch (KeyNotFoundException ex)
+            {
+                return NotFound(new { message = ex.Message });
+            }
+            catch (InvalidOperationException ex)
+            {
+                return BadRequest(new { message = ex.Message });
+            }
+            catch (ArgumentException ex)
             {
                 return BadRequest(new { message = ex.Message });
             }

--- a/backend/absence_manager_backend/absence_manager_backend/Program.cs
+++ b/backend/absence_manager_backend/absence_manager_backend/Program.cs
@@ -21,6 +21,7 @@ builder.Services.AddScoped<AbsenceRequestLogic>();
 builder.Services.AddScoped<IAppUserResolver, AppUserResolver>();
 builder.Services.AddScoped<IMsGraphLogic, MsGraphLogic>();
 builder.Services.AddScoped<ICurrentUserService, CurrentUserService>();
+builder.Services.AddScoped<ICurrentUserGraphSyncService, CurrentUserGraphSyncService>();
 
 var allowedOrigins = builder.Configuration.GetSection("Cors:AllowedOrigins").Get<string[]>();
 

--- a/backend/absence_manager_backend/absence_manager_backend/Program.cs
+++ b/backend/absence_manager_backend/absence_manager_backend/Program.cs
@@ -15,7 +15,7 @@ builder.Services.AddScoped(typeof(Repository<>));
 builder.Services.AddSingleton<DtoProvider>();
 builder.Services.AddScoped<OfficeBookingLogic>();
 builder.Services.AddScoped<OfficeManagementLogic>();
-builder.Services.AddScoped<UserLogic>();
+builder.Services.AddScoped<IUserLogic, UserLogic>();
 builder.Services.AddScoped<CalendarLogic>();
 builder.Services.AddScoped<AbsenceRequestLogic>();
 builder.Services.AddScoped<IAppUserResolver, AppUserResolver>();

--- a/frontend/absence_manager_frontend/src/app/app.ts
+++ b/frontend/absence_manager_frontend/src/app/app.ts
@@ -16,13 +16,13 @@ export class App implements OnInit, OnDestroy {
   isLoginPage = false;
 
   private readonly destroy$ = new Subject<void>();
-  private graphProfileSyncStarted = false;
+  private graphSyncStarted = false;
 
   constructor(
     private router: Router,
     private authService: AuthService,
     private userService: UserService
-  ) {}
+  ) { }
 
   async ngOnInit(): Promise<void> {
     await this.bootstrapAuth();
@@ -36,11 +36,11 @@ export class App implements OnInit, OnDestroy {
       )
       .subscribe(account => {
         if (!account) {
-          this.graphProfileSyncStarted = false;
+          this.graphSyncStarted = false;
           return;
         }
 
-        this.startGraphProfileSync();
+        this.startGraphSync();
       });
 
     this.updateRouteState();
@@ -63,25 +63,25 @@ export class App implements OnInit, OnDestroy {
       await this.authService.bootstrap();
 
       if (this.authService.isLoggedIn()) {
-        this.startGraphProfileSync();
+        this.startGraphSync();
       }
     } catch (error) {
       console.error('Auth bootstrap failed in App.', error);
     }
   }
 
-  private startGraphProfileSync(): void {
-    if (this.graphProfileSyncStarted) {
+  private startGraphSync(): void {
+    if (this.graphSyncStarted) {
       return;
     }
 
-    this.graphProfileSyncStarted = true;
+    this.graphSyncStarted = true;
 
-    this.userService.syncGraphProfile()
+    this.userService.syncCurrentUserFromGraph()
       .pipe(takeUntil(this.destroy$))
       .subscribe({
         error: err => {
-          console.warn('Graph profil szinkron sikertelen.', err);
+          console.warn('Graph szinkron sikertelen.', err);
         }
       });
   }

--- a/frontend/absence_manager_frontend/src/app/auth/auth-service.ts
+++ b/frontend/absence_manager_frontend/src/app/auth/auth-service.ts
@@ -3,6 +3,12 @@ import { AccountInfo, AuthenticationResult } from '@azure/msal-browser';
 import { BehaviorSubject } from 'rxjs/internal/BehaviorSubject';
 import { getApiScope, getMsalInstance, getPostLogoutRedirectUri } from './entra-auth-config';
 
+export type AuthProcessState =
+  | 'initializing'
+  | 'idle'
+  | 'loggingIn'
+  | 'loggingOut';
+
 @Injectable({
   providedIn: 'root',
 })
@@ -10,11 +16,14 @@ export class AuthService {
   private readonly accountSubject = new BehaviorSubject<AccountInfo | null>(null);
   private readonly tokenSubject = new BehaviorSubject<string | null>(null);
 
+  private readonly authProcessStateSubject = new BehaviorSubject<AuthProcessState>('initializing');
+
   private initialized = false;
   private bootstrapPromise: Promise<void> | null = null;
 
   readonly account$ = this.accountSubject.asObservable();
   readonly token$ = this.tokenSubject.asObservable();
+  readonly authProcessState$ = this.authProcessStateSubject.asObservable();
 
   async bootstrap(): Promise<void> {
     if (!this.bootstrapPromise) {
@@ -25,8 +34,16 @@ export class AuthService {
   }
 
   private async bootstrapInternal(): Promise<void> {
-    await this.initialize();
-    await this.handleRedirect();
+    this.authProcessStateSubject.next('initializing');
+
+    try {
+      await this.initialize();
+      await this.handleRedirect();
+    } finally {
+      if (this.authProcessStateSubject.value === 'initializing') {
+        this.authProcessStateSubject.next('idle');
+      }
+    }
   }
 
   async initialize(): Promise<void> {
@@ -45,6 +62,7 @@ export class AuthService {
     if (authResult?.account) {
       getMsalInstance().setActiveAccount(authResult.account);
       this.accountSubject.next(authResult.account);
+      this.authProcessStateSubject.next('idle');
       return;
     }
 
@@ -52,37 +70,53 @@ export class AuthService {
 
     if (activeAccount) {
       this.accountSubject.next(activeAccount);
+      this.authProcessStateSubject.next('idle');
       return;
     }
 
     if (accounts.length > 0) {
       getMsalInstance().setActiveAccount(accounts[0]);
       this.accountSubject.next(accounts[0]);
+      this.authProcessStateSubject.next('idle');
       return;
     }
 
     this.accountSubject.next(null);
     this.tokenSubject.next(null);
+    this.authProcessStateSubject.next('idle');
   }
 
   async login(): Promise<void> {
-    await this.initialize();
+    this.authProcessStateSubject.next('loggingIn');
 
-    await getMsalInstance().loginRedirect({
-      scopes: ['openid', 'profile', 'email', getApiScope()]
-    });
+    try {
+      await this.initialize();
+
+      await getMsalInstance().loginRedirect({
+        scopes: ['openid', 'profile', 'email', getApiScope()]
+      });
+    } catch (error) {
+      this.authProcessStateSubject.next('idle');
+      throw error;
+    }
   }
 
   async logout(): Promise<void> {
-    await this.initialize();
+    this.authProcessStateSubject.next('loggingOut');
 
-    this.accountSubject.next(null);
-    this.tokenSubject.next(null);
-    this.bootstrapPromise = null;
+    try {
+      await this.initialize();
 
-    await getMsalInstance().logoutRedirect({
-      postLogoutRedirectUri: getPostLogoutRedirectUri()
-    });
+      this.tokenSubject.next(null);
+      this.bootstrapPromise = null;
+
+      await getMsalInstance().logoutRedirect({
+        postLogoutRedirectUri: getPostLogoutRedirectUri()
+      });
+    } catch (error) {
+      this.authProcessStateSubject.next('idle');
+      throw error;
+    }
   }
 
   async acquireApiToken(): Promise<string | null> {

--- a/frontend/absence_manager_frontend/src/app/components/navbar/navbar.html
+++ b/frontend/absence_manager_frontend/src/app/components/navbar/navbar.html
@@ -10,7 +10,7 @@
             <span>Profil</span>
         </a>
 
-        
+
 
         <a class="nav-link d-flex align-items-center gap-2" routerLink="/calendar" routerLinkActive="active"
             *ngIf="isLoggedIn">
@@ -18,12 +18,8 @@
             <span>Naptár</span>
         </a>
 
-        <a
-            class="nav-link d-flex align-items-center gap-2"
-            routerLink="/my-absence-requests"
-            routerLinkActive="active"
-            *ngIf="isLoggedIn"
-            >
+        <a class="nav-link d-flex align-items-center gap-2" routerLink="/my-absence-requests" routerLinkActive="active"
+            *ngIf="isLoggedIn">
             <i class="bi bi-calendar-check"></i>
             <span>Saját kérelmek</span>
         </a>
@@ -41,26 +37,33 @@
 
     <div class="mt-auto"></div>
 
-    <div class="px-3 mb-3" *ngIf="isLoggedIn; else loggedOutBlock">
-        <a class="sidebar-user pt-3 mt-3 mb-1 border-top text-decoration-none d-block" routerLink="/profile"
-            routerLinkActive="active" *ngIf="userProfile">
-            <div class="d-flex align-items-center gap-2">
-                <div class="avatar">
-                    {{ getInitials(userProfile.displayName) }}
-                </div>
+    <div class="px-3 mb-3">
+        <div class="auth-transition pt-3 mt-3 border-top" *ngIf="isAuthTransition">
+            <span class="auth-spinner"></span>
+            <span>{{ authTransitionLabel }}</span>
+        </div>
 
-                <div class="user-meta">
-                    <div class="user-name">{{ userProfile.displayName }}</div>
-                    <div class="user-dept">
-                        {{ userProfile.department || userProfile.email || 'Bejelentkezett felhasználó' }}
+        <ng-container *ngIf="!isAuthTransition">
+            <a class="sidebar-user pt-3 mt-3 mb-1 border-top text-decoration-none d-block" routerLink="/profile"
+                routerLinkActive="active" *ngIf="isLoggedIn && userProfile; else loggedOutBlock">
+                <div class="d-flex align-items-center gap-2">
+                    <div class="avatar">
+                        {{ getInitials(userProfile.displayName) }}
+                    </div>
+
+                    <div class="user-meta">
+                        <div class="user-name">{{ userProfile.displayName }}</div>
+                        <div class="user-dept">
+                            {{ userProfile.department || userProfile.email || 'Bejelentkezett felhasználó' }}
+                        </div>
                     </div>
                 </div>
-            </div>
-        </a>
+            </a>
+        </ng-container>
     </div>
 
     <ng-template #loggedOutBlock>
-        <div class="px-3 mb-3 pt-3 mt-3 border-top">
+        <div class="pt-3 mt-3 border-top">
             <a routerLink="/login" class="btn btn-primary w-100">
                 Bejelentkezés
             </a>

--- a/frontend/absence_manager_frontend/src/app/components/navbar/navbar.sass
+++ b/frontend/absence_manager_frontend/src/app/components/navbar/navbar.sass
@@ -1,10 +1,10 @@
 @use '../../../../src/styles' as *
 
 .sidebar
-    width: 270px
-    min-height: 100vh
-    background: white
-    border-right: 1px solid $border-color
+  width: 270px
+  min-height: 100vh
+  background: white
+  border-right: 1px solid $border-color
 
 .sidebar-header
   display: flex
@@ -15,35 +15,31 @@
   max-width: 160px
   height: auto
   display: block
-        
 
 .sidebar-nav
-    .nav-link
-        border-radius: 0.5rem
-        padding: 0.65rem 0.8rem
-        color: $dark
-        text-decoration: none
-        transition: background 0.15s ease, color 0.15s ease
+  .nav-link
+    border-radius: 0.5rem
+    padding: 0.65rem 0.8rem
+    color: $dark
+    text-decoration: none
+    transition: background 0.15s ease, color 0.15s ease
 
-        i
-            font-size: 1.2rem
-            line-height: 1
+    i
+      font-size: 1.2rem
+      line-height: 1
 
-        &:hover
-            background: $light-100
-            color: $dark
+    &:hover
+      background: $light-100
+      color: $dark
 
-        &.active
-            background: $primary-500
-            color: $light-500
-            font-weight: 500
+    &.active
+      background: $primary-500
+      color: $light-500
+      font-weight: 500
 
-        &.active:hover
-            background: $primary-500
-            color: $light-500
-
-.sidebar-user
-    border-top: 1px solid $border-color
+    &.active:hover
+      background: $primary-500
+      color: $light-500
 
 .sidebar-user
   border-top: 1px solid $border-color
@@ -79,3 +75,27 @@
 .user-dept
   font-size: 0.875rem
   opacity: 0.8
+
+.auth-transition
+  display: flex
+  align-items: center
+  gap: 10px
+  color: $dark
+  font-size: 0.9rem
+  font-weight: 500
+  min-height: 48px
+
+.auth-spinner
+  width: 18px
+  height: 18px
+  min-width: 18px
+  border-radius: 50%
+  border: 2px solid $border-color
+  border-top-color: $primary-500
+  animation: authSpin 0.75s linear infinite
+
+@keyframes authSpin
+  from
+    transform: rotate(0deg)
+  to
+    transform: rotate(360deg)

--- a/frontend/absence_manager_frontend/src/app/components/navbar/navbar.ts
+++ b/frontend/absence_manager_frontend/src/app/components/navbar/navbar.ts
@@ -1,7 +1,7 @@
 import { Component, OnDestroy, OnInit } from '@angular/core';
-import { distinctUntilChanged, Subject, takeUntil } from 'rxjs';
+import { combineLatest, distinctUntilChanged, Subject, takeUntil } from 'rxjs';
 import { UserProfile } from '../../models/app-user-models';
-import { AuthService } from '../../auth/auth-service';
+import { AuthProcessState, AuthService } from '../../auth/auth-service';
 import { UserService } from '../../services/user.service';
 import { AccountInfo } from '@azure/msal-browser';
 
@@ -15,28 +15,43 @@ export class Navbar implements OnInit, OnDestroy {
   userProfile: UserProfile | null = null;
   loading = true;
   isLoggedIn = false;
+  authProcessState: AuthProcessState = 'initializing';
 
   private readonly destroy$ = new Subject<void>();
 
   constructor(public authService: AuthService) { }
 
   ngOnInit(): void {
-    this.authService.account$
-      .pipe(
-        distinctUntilChanged((previous, current) => previous?.homeAccountId === current?.homeAccountId),
-        takeUntil(this.destroy$)
-      )
-      .subscribe(account => {
+    combineLatest([
+      this.authService.account$.pipe(
+        distinctUntilChanged((previous, current) =>
+          previous?.homeAccountId === current?.homeAccountId
+        )
+      ),
+      this.authService.authProcessState$
+    ])
+      .pipe(takeUntil(this.destroy$))
+      .subscribe(([account, authProcessState]) => {
+        this.authProcessState = authProcessState;
+        this.loading = this.isAuthTransition;
+
+        if (this.isAuthTransition) {
+          if (this.isLoggingOut) {
+            this.isLoggedIn = false;
+            this.userProfile = null;
+          }
+
+          return;
+        }
+
         this.isLoggedIn = !!account;
 
         if (!account) {
           this.userProfile = null;
-          this.loading = false;
           return;
         }
 
         this.userProfile = this.createProfileFromAccount(account);
-        this.loading = false;
       });
   }
 
@@ -65,5 +80,33 @@ export class Navbar implements OnInit, OnDestroy {
       department: '',
       jobTitle: ''
     };
+  }
+
+  get isInitializing(): boolean {
+    return this.authProcessState === 'initializing';
+  }
+
+  get isLoggingIn(): boolean {
+    return this.authProcessState === 'loggingIn';
+  }
+
+  get isLoggingOut(): boolean {
+    return this.authProcessState === 'loggingOut';
+  }
+
+  get isAuthTransition(): boolean {
+    return this.isInitializing || this.isLoggingIn || this.isLoggingOut;
+  }
+
+  get authTransitionLabel(): string {
+    if (this.isLoggingIn) {
+      return 'Bejelentkezés...';
+    }
+
+    if (this.isLoggingOut) {
+      return 'Kijelentkezés...';
+    }
+
+    return 'Betöltés...';
   }
 }

--- a/frontend/absence_manager_frontend/src/app/services/user.service.ts
+++ b/frontend/absence_manager_frontend/src/app/services/user.service.ts
@@ -16,6 +16,33 @@ export type MeResponse = {
   roles: string[];
 };
 
+export interface GraphAppUserDto {
+  entraObjectId: string;
+  appUserId?: string | null;
+  displayName?: string | null;
+  email?: string | null;
+  userPrincipalName?: string | null;
+  department?: string | null;
+  jobTitle?: string | null;
+  officeLocation?: string | null;
+  isKnownLocalUser: boolean;
+  isActiveLocalUser: boolean;
+}
+
+export interface AppUserHierarchyDto {
+  currentUser?: GraphAppUserDto | null;
+  manager?: GraphAppUserDto | null;
+  directReports: GraphAppUserDto[];
+}
+
+export interface UserContextDto {
+  profile: UserProfile;
+  hierarchy: AppUserHierarchyDto;
+  isManager: boolean;
+  roles: string[];
+  lastGraphSyncAtUtc?: string | null;
+}
+
 @Injectable({
   providedIn: 'root'
 })
@@ -31,9 +58,9 @@ export class UserService {
     );
   }
 
-  syncGraphProfile(): Observable<void> {
-    return this.http.post<void>(
-      `${this.configService.apiUrl}/users/me/sync-graph-profile`,
+  syncCurrentUserFromGraph(): Observable<UserContextDto> {
+    return this.http.post<UserContextDto>(
+      `${this.configService.apiUrl}/users/me/sync-from-graph`,
       {}
     );
   }


### PR DESCRIPTION
## Leírás

Ez a PR egységesíti a Microsoft Graph alapú felhasználói szinkron működését.

Korábban a profiladatok és a hierarchia adatok külön logikán keresztül frissültek. Emiatt előfordulhatott, hogy egy korábban már bejelentkezett felhasználónál nem jöttek létre utólag a manager / direct report kapcsolatok, ezért például a jóváhagyási oldal nem működött megfelelően manager felhasználónál.

## Cél

Az új működés szerint login után egy egységes backend végpont frissíti:

- az aktuális felhasználó Graph profiladatait,
- a manager kapcsolatot,
- a direct report kapcsolatokat,
- a hiányzó lokális AppUser rekordokat,
- az AppUserManagerRelation rekordokat.

## Főbb módosítások

### Backend

- Új endpoint készült:

```http
POST /api/users/me/sync-from-graph
```

- Létrejött egy új `CurrentUserGraphSyncService`.
- A `UserLogic` interface mögé került (`IUserLogic`).
- A `GET /api/users/me/hierarchy` már csak lokális adatbázisból olvas.
- A Graph sync közben létrejönnek a hiányzó lokális `AppUser` rekordok.
- A régi `POST /api/users/me/sync-graph-profile` endpoint deprecated lett.

### Frontend

- A frontend login/app start után már az új endpointot hívja:

```http
POST /api/users/me/sync-from-graph
```

- A régi `syncGraphProfile()` hívás lecserélésre került.
- Login/logout köztes állapotnál a sidebar már nem villantja be a Bejelentkezés gombot.
- Bejelentkezés/kijelentkezés közben töltő állapot jelenik meg.

## Elvárt működés

- Bejelentkezés után lefut az egységes Graph sync.
- Manager felhasználónál létrejönnek a direct report kapcsolatok.
- A jóváhagyási oldal működik managerként.
- A hierarchia GET endpoint már nem módosít adatot.
- Kijelentkezés közben nem villan be a Bejelentkezés gomb.

## Tesztelés

Tesztelt esetek:

- Backend build sikeres.
- Frontend build sikeres.
- Lokális PostgreSQL kapcsolat helyreállítva.
- Bejelentkezés után meghívódik az új sync endpoint.
- Logout közben a sidebar töltő állapotot mutat.
- Login/logout alatt nem jelenik meg hibás köztes Bejelentkezés gomb.
- Manager/direct report relációk szinkronizációja működésre előkészítve.

## Megjegyzés

A régi `sync-graph-profile` endpoint még nem lett törölve, csak deprecated jelölést kapott, hogy ne törjön el esetleges régi klienshívás.
