### PR TITLE
Add User Activity Audit Logging

### DIFF
--- a/backend/absence_manager_backend/Data/AbsenceManagerDbContext.cs
+++ b/backend/absence_manager_backend/Data/AbsenceManagerDbContext.cs
@@ -12,6 +12,7 @@ namespace Data
         public DbSet<OfficeBooking> OfficeBookings => Set<OfficeBooking>();
         public DbSet<AbsenceRequest> AbsenceRequests => Set<AbsenceRequest>();
         public DbSet<AppUserManagerRelation> AppUserManagerRelations => Set<AppUserManagerRelation>();
+        public DbSet<UserActivityLog> UserActivityLogs => Set<UserActivityLog>();
 
         public AbsenceManagerDbContext(DbContextOptions<AbsenceManagerDbContext> options)
             : base(options)
@@ -130,6 +131,77 @@ namespace Data
                     .IsUnique()
                     .HasFilter("\"IsActive\" = true")
                     .HasDatabaseName("UX_AppUserManagerRelations_OneActivePerUser");
+            });
+
+            // -------------------------
+            // UserActivityLog
+            // -------------------------
+            modelBuilder.Entity<UserActivityLog>(entity =>
+            {
+                entity.ToTable("UserActivityLogs");
+
+                entity.HasKey(x => x.Id);
+
+                entity.Property(x => x.Id)
+                    .HasMaxLength(50)
+                    .IsRequired();
+
+                entity.Property(x => x.CreatedAtUtc)
+                    .IsRequired();
+
+                entity.Property(x => x.ActorUserId)
+                    .HasMaxLength(50);
+
+                entity.Property(x => x.ActorEntraObjectId)
+                    .HasMaxLength(100);
+
+                entity.Property(x => x.TenantId)
+                    .HasMaxLength(100);
+
+                entity.Property(x => x.Action)
+                    .HasMaxLength(100)
+                    .IsRequired();
+
+                entity.Property(x => x.EntityType)
+                    .HasMaxLength(100)
+                    .IsRequired();
+
+                entity.Property(x => x.EntityId)
+                    .HasMaxLength(100);
+
+                entity.Property(x => x.Outcome)
+                    .HasMaxLength(30)
+                    .IsRequired();
+
+                entity.Property(x => x.IpAddress)
+                    .HasMaxLength(100);
+
+                entity.Property(x => x.UserAgent)
+                    .HasMaxLength(500);
+
+                entity.Property(x => x.RequestMethod)
+                    .HasMaxLength(20);
+
+                entity.Property(x => x.RequestPath)
+                    .HasMaxLength(500);
+
+                entity.Property(x => x.CorrelationId)
+                    .HasMaxLength(100);
+
+                entity.Property(x => x.MetadataJson)
+                    .HasColumnType("jsonb");
+
+                entity.HasIndex(x => x.CreatedAtUtc)
+                    .HasDatabaseName("IX_UserActivityLogs_CreatedAtUtc");
+
+                entity.HasIndex(x => x.ActorUserId)
+                    .HasDatabaseName("IX_UserActivityLogs_ActorUserId");
+
+                entity.HasIndex(x => x.Action)
+                    .HasDatabaseName("IX_UserActivityLogs_Action");
+
+                entity.HasIndex(x => new { x.EntityType, x.EntityId })
+                    .HasDatabaseName("IX_UserActivityLogs_EntityType_EntityId");
             });
 
             // -------------------------

--- a/backend/absence_manager_backend/Data/Migrations/20260529065341_AddUserActivityLogs.Designer.cs
+++ b/backend/absence_manager_backend/Data/Migrations/20260529065341_AddUserActivityLogs.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Data.Migrations
 {
     [DbContext(typeof(AbsenceManagerDbContext))]
-    partial class AbsenceManagerDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260529065341_AddUserActivityLogs")]
+    partial class AddUserActivityLogs
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/absence_manager_backend/Data/Migrations/20260529065341_AddUserActivityLogs.cs
+++ b/backend/absence_manager_backend/Data/Migrations/20260529065341_AddUserActivityLogs.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddUserActivityLogs : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "UserActivityLogs",
+                columns: table => new
+                {
+                    Id = table.Column<string>(type: "character varying(50)", maxLength: 50, nullable: false),
+                    CreatedAtUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    ActorUserId = table.Column<string>(type: "character varying(50)", maxLength: 50, nullable: true),
+                    ActorEntraObjectId = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: true),
+                    TenantId = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: true),
+                    Action = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: false),
+                    EntityType = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: false),
+                    EntityId = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: true),
+                    Outcome = table.Column<string>(type: "character varying(30)", maxLength: 30, nullable: false),
+                    IpAddress = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: true),
+                    UserAgent = table.Column<string>(type: "character varying(500)", maxLength: 500, nullable: true),
+                    RequestMethod = table.Column<string>(type: "character varying(20)", maxLength: 20, nullable: true),
+                    RequestPath = table.Column<string>(type: "character varying(500)", maxLength: 500, nullable: true),
+                    CorrelationId = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: true),
+                    MetadataJson = table.Column<string>(type: "jsonb", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_UserActivityLogs", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_UserActivityLogs_Action",
+                table: "UserActivityLogs",
+                column: "Action");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_UserActivityLogs_ActorUserId",
+                table: "UserActivityLogs",
+                column: "ActorUserId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_UserActivityLogs_CreatedAtUtc",
+                table: "UserActivityLogs",
+                column: "CreatedAtUtc");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_UserActivityLogs_EntityType_EntityId",
+                table: "UserActivityLogs",
+                columns: new[] { "EntityType", "EntityId" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "UserActivityLogs");
+        }
+    }
+}

--- a/backend/absence_manager_backend/Entities/Dtos/UserActivityLogDtos/UserActivityLogFilterOptionsDto.cs
+++ b/backend/absence_manager_backend/Entities/Dtos/UserActivityLogDtos/UserActivityLogFilterOptionsDto.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Entities.Dtos.UserActivityLogDtos
+{
+    public class UserActivityLogFilterOptionsDto
+    {
+        public IReadOnlyList<UserActivityLogOptionDto> Actions { get; set; } =
+            Array.Empty<UserActivityLogOptionDto>();
+
+        public IReadOnlyList<UserActivityLogOptionDto> EntityTypes { get; set; } =
+            Array.Empty<UserActivityLogOptionDto>();
+
+        public IReadOnlyList<UserActivityLogOptionDto> Outcomes { get; set; } =
+            Array.Empty<UserActivityLogOptionDto>();
+    }
+
+    public class UserActivityLogOptionDto
+    {
+        public string Value { get; set; } = null!;
+
+        public string Label { get; set; } = null!;
+    }
+}

--- a/backend/absence_manager_backend/Entities/Dtos/UserActivityLogDtos/UserActivityLogListResultDto.cs
+++ b/backend/absence_manager_backend/Entities/Dtos/UserActivityLogDtos/UserActivityLogListResultDto.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Entities.Dtos.UserActivityLogDtos
+{
+    public class UserActivityLogListResultDto
+    {
+        public int Page { get; set; }
+
+        public int PageSize { get; set; }
+
+        public int TotalCount { get; set; }
+
+        public IReadOnlyList<UserActivityLogViewDto> Items { get; set; } = Array.Empty<UserActivityLogViewDto>();
+    }
+}

--- a/backend/absence_manager_backend/Entities/Dtos/UserActivityLogDtos/UserActivityLogViewDto.cs
+++ b/backend/absence_manager_backend/Entities/Dtos/UserActivityLogDtos/UserActivityLogViewDto.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Entities.Dtos.UserActivityLogDtos
+{
+    public class UserActivityLogViewDto
+    {
+        public string Id { get; set; } = null!;
+
+        public DateTime CreatedAtUtc { get; set; }
+
+        public string? ActorUserId { get; set; }
+
+        public string? ActorDisplayName { get; set; }
+
+        public string? ActorEmail { get; set; }
+
+        public string? ActorEntraObjectId { get; set; }
+
+        public string? TenantId { get; set; }
+
+        public string Action { get; set; } = null!;
+
+        public string EntityType { get; set; } = null!;
+
+        public string? EntityId { get; set; }
+
+        public string Outcome { get; set; } = null!;
+
+        public string? IpAddress { get; set; }
+
+        public string? UserAgent { get; set; }
+
+        public string? RequestMethod { get; set; }
+
+        public string? RequestPath { get; set; }
+
+        public string? CorrelationId { get; set; }
+
+        public string? MetadataJson { get; set; }
+    }
+}

--- a/backend/absence_manager_backend/Entities/Models/UserActivityLog.cs
+++ b/backend/absence_manager_backend/Entities/Models/UserActivityLog.cs
@@ -1,0 +1,44 @@
+﻿using Entities.Helpers;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Entities.Models
+{
+    public class UserActivityLog : IIdEntity
+    {
+        public UserActivityLog()
+        {
+            Id = Guid.NewGuid().ToString();
+        }
+        public string Id { get; set; } = null!;
+
+        public DateTime CreatedAtUtc { get; set; }
+
+        public string? ActorUserId { get; set; }
+
+        public string? ActorEntraObjectId { get; set; }
+
+        public string? TenantId { get; set; }
+
+        public string Action { get; set; } = null!;
+
+        public string EntityType { get; set; } = null!;
+
+        public string? EntityId { get; set; }
+
+        public string Outcome { get; set; } = "Success";
+
+        public string? IpAddress { get; set; }
+
+        public string? UserAgent { get; set; }
+
+        public string? RequestMethod { get; set; }
+
+        public string? RequestPath { get; set; }
+
+        public string? CorrelationId { get; set; }
+
+        public string? MetadataJson { get; set; }
+    }
+}

--- a/backend/absence_manager_backend/Logic/Helper/UserActivityLogOutcomes.cs
+++ b/backend/absence_manager_backend/Logic/Helper/UserActivityLogOutcomes.cs
@@ -1,0 +1,97 @@
+﻿using Data;
+using Entities.Models;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Text.Json;
+
+namespace Logic.Helper
+{
+    public static class UserActivityLogOutcomes
+    {
+        public const string Success = "Success";
+        public const string Failed = "Failed";
+        public const string Forbidden = "Forbidden";
+    }
+
+    public interface IUserActivityLogger
+    {
+        Task LogAsync(
+            string action,
+            string entityType,
+            string? entityId,
+            string? actorUserId,
+            object? metadata = null,
+            string outcome = UserActivityLogOutcomes.Success,
+            CancellationToken cancellationToken = default);
+    }
+
+    public class UserActivityLogger : IUserActivityLogger
+    {
+        private static readonly JsonSerializerOptions JsonOptions = new()
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            WriteIndented = false
+        };
+
+        private readonly AbsenceManagerDbContext _dbContext;
+        private readonly IHttpContextAccessor _httpContextAccessor;
+        private readonly ICurrentUserService _currentUserService;
+        private readonly ILogger<UserActivityLogger> _logger;
+
+        public UserActivityLogger(AbsenceManagerDbContext dbContext, IHttpContextAccessor httpContextAccessor, ICurrentUserService currentUserService, ILogger<UserActivityLogger> logger)
+        {
+            _dbContext = dbContext;
+            _httpContextAccessor = httpContextAccessor;
+            _currentUserService = currentUserService;
+            _logger = logger;
+        }
+
+        public async Task LogAsync(string action, string entityType, string? entityId, string? actorUserId, object? metadata = null, string outcome = UserActivityLogOutcomes.Success, CancellationToken cancellationToken = default)
+        {
+            try
+            {
+                var httpContext = _httpContextAccessor.HttpContext;
+
+                var log = new UserActivityLog
+                {
+                    CreatedAtUtc = DateTime.UtcNow,
+                    ActorUserId = actorUserId,
+                    ActorEntraObjectId = _currentUserService.GetEntraObjectId(),
+                    TenantId = _currentUserService.GetTenantId(),
+                    Action = action,
+                    EntityType = entityType,
+                    EntityId = entityId,
+                    Outcome = outcome,
+                    IpAddress = httpContext?.Connection.RemoteIpAddress?.ToString(),
+                    UserAgent = httpContext?.Request.Headers.UserAgent.ToString(),
+                    RequestMethod = httpContext?.Request.Method,
+                    RequestPath = httpContext?.Request.Path.Value,
+                    CorrelationId = httpContext?.TraceIdentifier,
+                    MetadataJson = metadata == null
+                        ? null
+                        : JsonSerializer.Serialize(metadata, JsonOptions)
+                };
+
+                _dbContext.UserActivityLogs.Add(log);
+                await _dbContext.SaveChangesAsync(cancellationToken);
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(
+                    ex,
+                    "User activity audit log write failed. Action={Action}, EntityType={EntityType}, EntityId={EntityId}, ActorUserId={ActorUserId}",
+                    action,
+                    entityType,
+                    entityId,
+                    actorUserId);
+            }
+        }
+    }
+}

--- a/backend/absence_manager_backend/Logic/Helper/UserActivityLogger.cs
+++ b/backend/absence_manager_backend/Logic/Helper/UserActivityLogger.cs
@@ -16,6 +16,29 @@ namespace Logic.Helper
         public const string Forbidden = "Forbidden";
     }
 
+    public static class UserActivityLogActions
+    {
+        public const string OfficeBookingCreated = "OfficeBookingCreated";
+        public const string OfficeBookingCancelled = "OfficeBookingCancelled";
+
+        public const string AbsenceRequestCreated = "AbsenceRequestCreated";
+        public const string AbsenceRequestCancelled = "AbsenceRequestCancelled";
+        public const string AbsenceRequestApproved = "AbsenceRequestApproved";
+        public const string AbsenceRequestRejected = "AbsenceRequestRejected";
+
+        public const string UserGraphSyncCompleted = "UserGraphSyncCompleted";
+        public const string UserGraphSyncFailed = "UserGraphSyncFailed";
+
+        public const string UnauthorizedActionAttempt = "UnauthorizedActionAttempt";
+    }
+
+    public static class UserActivityLogEntityTypes
+    {
+        public const string OfficeBooking = "OfficeBooking";
+        public const string AbsenceRequest = "AbsenceRequest";
+        public const string AppUser = "AppUser";
+    }
+
     public interface IUserActivityLogger
     {
         Task LogAsync(

--- a/backend/absence_manager_backend/Logic/Logic/AbsenceRequestLogic.cs
+++ b/backend/absence_manager_backend/Logic/Logic/AbsenceRequestLogic.cs
@@ -176,8 +176,8 @@ namespace Logic.Logic
             request.User = user;
 
             await _activityLogger.LogAsync(
-                action: "AbsenceRequestCreated",
-                entityType: "AbsenceRequest",
+                action: UserActivityLogActions.AbsenceRequestCreated,
+                entityType: UserActivityLogEntityTypes.AbsenceRequest,
                 entityId: request.Id,
                 actorUserId: currentUserId,
                 metadata: new
@@ -245,8 +245,8 @@ namespace Logic.Logic
             if (request.UserId != currentUserId)
             {
                 await _activityLogger.LogAsync(
-                    action: "UnauthorizedActionAttempt",
-                    entityType: "AbsenceRequest",
+                    action: UserActivityLogActions.UnauthorizedActionAttempt,
+                    entityType: UserActivityLogEntityTypes.AbsenceRequest,
                     entityId: id,
                     actorUserId: currentUserId,
                     metadata: new
@@ -276,8 +276,8 @@ namespace Logic.Logic
             await _dbContext.SaveChangesAsync(cancellationToken);
 
             await _activityLogger.LogAsync(
-                action: "AbsenceRequestCancelled",
-                entityType: "AbsenceRequest",
+                action: UserActivityLogActions.AbsenceRequestCancelled,
+                entityType: UserActivityLogEntityTypes.AbsenceRequest,
                 entityId: request.Id,
                 actorUserId: currentUserId,
                 metadata: new
@@ -446,8 +446,8 @@ namespace Logic.Logic
             if (!isActiveManager)
             {
                 await _activityLogger.LogAsync(
-                    action: "UnauthorizedActionAttempt",
-                    entityType: "AbsenceRequest",
+                    action: UserActivityLogActions.UnauthorizedActionAttempt,
+                    entityType: UserActivityLogEntityTypes.AbsenceRequest,
                     entityId: absenceRequest.Id,
                     actorUserId: managerUserId,
                     metadata: new
@@ -482,9 +482,9 @@ namespace Logic.Logic
 
             await _activityLogger.LogAsync(
                 action: targetStatus == AbsenceRequestStatus.Approved
-                    ? "AbsenceRequestApproved"
-                    : "AbsenceRequestRejected",
-                entityType: "AbsenceRequest",
+                    ? UserActivityLogActions.AbsenceRequestApproved
+                    : UserActivityLogActions.AbsenceRequestRejected,
+                entityType: UserActivityLogEntityTypes.AbsenceRequest,
                 entityId: absenceRequest.Id,
                 actorUserId: managerUserId,
                 metadata: new

--- a/backend/absence_manager_backend/Logic/Logic/AbsenceRequestLogic.cs
+++ b/backend/absence_manager_backend/Logic/Logic/AbsenceRequestLogic.cs
@@ -2,6 +2,7 @@
 using Entities.Dtos.AbsenceRequestDtos;
 using Entities.Enums;
 using Entities.Models;
+using Logic.Helper;
 using Microsoft.EntityFrameworkCore;
 
 namespace Logic.Logic
@@ -9,10 +10,12 @@ namespace Logic.Logic
     public class AbsenceRequestLogic
     {
         private readonly AbsenceManagerDbContext _dbContext;
+        private readonly IUserActivityLogger _activityLogger;
 
-        public AbsenceRequestLogic(AbsenceManagerDbContext dbContext)
+        public AbsenceRequestLogic(AbsenceManagerDbContext dbContext, IUserActivityLogger activityLogger)
         {
             _dbContext = dbContext;
+            _activityLogger = activityLogger;
         }
 
         public async Task<IReadOnlyList<AbsenceRequestApprovalDto>> GetReviewedApprovalsForManagerAsync(string managerUserId, CancellationToken cancellationToken = default)
@@ -172,6 +175,21 @@ namespace Logic.Logic
 
             request.User = user;
 
+            await _activityLogger.LogAsync(
+                action: "AbsenceRequestCreated",
+                entityType: "AbsenceRequest",
+                entityId: request.Id,
+                actorUserId: currentUserId,
+                metadata: new
+                {
+                    request.Type,
+                    request.Status,
+                    request.DateFrom,
+                    request.DateTo,
+                    HasReason = !string.IsNullOrWhiteSpace(request.Reason)
+                },
+                cancellationToken: cancellationToken);
+
             return ToViewDto(request);
         }
 
@@ -225,7 +243,26 @@ namespace Logic.Logic
                 ?? throw new KeyNotFoundException("Request not found.");
 
             if (request.UserId != currentUserId)
+            {
+                await _activityLogger.LogAsync(
+                    action: "UnauthorizedActionAttempt",
+                    entityType: "AbsenceRequest",
+                    entityId: id,
+                    actorUserId: currentUserId,
+                    metadata: new
+                    {
+                        AttemptedAction = "CancelAbsenceRequest",
+                        RequestOwnerUserId = request.UserId,
+                        request.Type,
+                        request.Status,
+                        request.DateFrom,
+                        request.DateTo
+                    },
+                    outcome: UserActivityLogOutcomes.Forbidden,
+                    cancellationToken: cancellationToken);
+
                 throw new UnauthorizedAccessException("You can only cancel your own request.");
+            }
 
             if (request.Status == AbsenceRequestStatus.Cancelled)
                 throw new InvalidOperationException("Request is already cancelled.");
@@ -237,6 +274,20 @@ namespace Logic.Logic
             request.UpdatedAtUtc = DateTime.UtcNow;
 
             await _dbContext.SaveChangesAsync(cancellationToken);
+
+            await _activityLogger.LogAsync(
+                action: "AbsenceRequestCancelled",
+                entityType: "AbsenceRequest",
+                entityId: request.Id,
+                actorUserId: currentUserId,
+                metadata: new
+                {
+                    request.Type,
+                    request.Status,
+                    request.DateFrom,
+                    request.DateTo
+                },
+                cancellationToken: cancellationToken);
         }
 
         public static AbsenceRequestType ParseType(string value)
@@ -394,6 +445,26 @@ namespace Logic.Logic
 
             if (!isActiveManager)
             {
+                await _activityLogger.LogAsync(
+                    action: "UnauthorizedActionAttempt",
+                    entityType: "AbsenceRequest",
+                    entityId: absenceRequest.Id,
+                    actorUserId: managerUserId,
+                    metadata: new
+                    {
+                        AttemptedAction = targetStatus == AbsenceRequestStatus.Approved
+                            ? "ApproveAbsenceRequest"
+                            : "RejectAbsenceRequest",
+                        RequestOwnerUserId = absenceRequest.UserId,
+                        RequestedTargetStatus = targetStatus,
+                        absenceRequest.Type,
+                        absenceRequest.Status,
+                        absenceRequest.DateFrom,
+                        absenceRequest.DateTo
+                    },
+                    outcome: UserActivityLogOutcomes.Forbidden,
+                    cancellationToken: cancellationToken);
+
                 throw new UnauthorizedAccessException("You are not allowed to review this absence request.");
             }
 
@@ -408,6 +479,24 @@ namespace Logic.Logic
                 : decisionComment.Trim();
 
             await _dbContext.SaveChangesAsync(cancellationToken);
+
+            await _activityLogger.LogAsync(
+                action: targetStatus == AbsenceRequestStatus.Approved
+                    ? "AbsenceRequestApproved"
+                    : "AbsenceRequestRejected",
+                entityType: "AbsenceRequest",
+                entityId: absenceRequest.Id,
+                actorUserId: managerUserId,
+                metadata: new
+                {
+                    RequestOwnerUserId = absenceRequest.UserId,
+                    absenceRequest.Type,
+                    absenceRequest.Status,
+                    absenceRequest.DateFrom,
+                    absenceRequest.DateTo,
+                    HasDecisionComment = !string.IsNullOrWhiteSpace(decisionComment)
+                },
+                cancellationToken: cancellationToken);
         }
     }
 }

--- a/backend/absence_manager_backend/Logic/Logic/CurrentUserGraphSyncService.cs
+++ b/backend/absence_manager_backend/Logic/Logic/CurrentUserGraphSyncService.cs
@@ -1,4 +1,5 @@
 ﻿using Entities.Dtos.AppUserDtos;
+using Logic.Helper;
 using System;
 using System.Collections.Generic;
 using System.Text;
@@ -9,13 +10,16 @@ namespace Logic.Logic
     {
         Task<UserContextDto> SyncCurrentUserFromGraphAsync(string currentUserId, CancellationToken cancellationToken = default);
     }
+
     public class CurrentUserGraphSyncService : ICurrentUserGraphSyncService
     {
         private readonly IUserLogic _userLogic;
+        private readonly IUserActivityLogger _activityLogger;
 
-        public CurrentUserGraphSyncService(IUserLogic userLogic)
+        public CurrentUserGraphSyncService(IUserLogic userLogic, IUserActivityLogger activityLogger)
         {
             _userLogic = userLogic;
+            _activityLogger = activityLogger;
         }
 
         public async Task<UserContextDto> SyncCurrentUserFromGraphAsync(string currentUserId, CancellationToken cancellationToken = default)
@@ -25,26 +29,69 @@ namespace Logic.Logic
                 throw new ArgumentException("Current user id is required.", nameof(currentUserId));
             }
 
-            await _userLogic.RefreshUserProfileAsync(currentUserId, cancellationToken);
+            var startedAtUtc = DateTime.UtcNow;
 
-            var hierarchy = await _userLogic.SyncCurrentUserHierarchyFromGraphAsync(
-                currentUserId,
-                cancellationToken);
-
-            var profile = _userLogic.GetUserProfile(currentUserId);
-
-            var isManager = hierarchy.DirectReports.Any();
-
-            return new UserContextDto
+            try
             {
-                Profile = profile,
-                Hierarchy = hierarchy,
-                IsManager = isManager,
-                Roles = isManager
-                    ? new[] { "Manager" }
-                    : Array.Empty<string>(),
-                LastGraphSyncAtUtc = DateTime.UtcNow
-            };
+                await _userLogic.RefreshUserProfileAsync(currentUserId, cancellationToken);
+
+                var hierarchy = await _userLogic.SyncCurrentUserHierarchyFromGraphAsync(
+                    currentUserId,
+                    cancellationToken);
+
+                var profile = _userLogic.GetUserProfile(currentUserId);
+
+                var isManager = hierarchy.DirectReports.Any();
+
+                var result = new UserContextDto
+                {
+                    Profile = profile,
+                    Hierarchy = hierarchy,
+                    IsManager = isManager,
+                    Roles = isManager
+                        ? new[] { "Manager" }
+                        : Array.Empty<string>(),
+                    LastGraphSyncAtUtc = DateTime.UtcNow
+                };
+
+                await _activityLogger.LogAsync(
+                    action: "UserGraphSyncCompleted",
+                    entityType: "AppUser",
+                    entityId: currentUserId,
+                    actorUserId: currentUserId,
+                    metadata: new
+                    {
+                        HasManager = hierarchy.Manager != null,
+                        DirectReportsCount = hierarchy.DirectReports.Count,
+                        IsManager = isManager,
+                        DurationMs = (int)(DateTime.UtcNow - startedAtUtc).TotalMilliseconds
+                    },
+                    cancellationToken: cancellationToken);
+
+                return result;
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                await _activityLogger.LogAsync(
+                    action: "UserGraphSyncFailed",
+                    entityType: "AppUser",
+                    entityId: currentUserId,
+                    actorUserId: currentUserId,
+                    metadata: new
+                    {
+                        ErrorType = ex.GetType().Name,
+                        ErrorMessage = ex.Message,
+                        DurationMs = (int)(DateTime.UtcNow - startedAtUtc).TotalMilliseconds
+                    },
+                    outcome: UserActivityLogOutcomes.Failed,
+                    cancellationToken: CancellationToken.None);
+
+                throw;
+            }
         }
     }
 }

--- a/backend/absence_manager_backend/Logic/Logic/CurrentUserGraphSyncService.cs
+++ b/backend/absence_manager_backend/Logic/Logic/CurrentUserGraphSyncService.cs
@@ -55,8 +55,8 @@ namespace Logic.Logic
                 };
 
                 await _activityLogger.LogAsync(
-                    action: "UserGraphSyncCompleted",
-                    entityType: "AppUser",
+                    action: UserActivityLogActions.UserGraphSyncCompleted,
+                    entityType: UserActivityLogEntityTypes.AppUser,
                     entityId: currentUserId,
                     actorUserId: currentUserId,
                     metadata: new
@@ -77,8 +77,8 @@ namespace Logic.Logic
             catch (Exception ex)
             {
                 await _activityLogger.LogAsync(
-                    action: "UserGraphSyncFailed",
-                    entityType: "AppUser",
+                    action: UserActivityLogActions.UserGraphSyncFailed,
+                    entityType: UserActivityLogEntityTypes.AppUser,
                     entityId: currentUserId,
                     actorUserId: currentUserId,
                     metadata: new

--- a/backend/absence_manager_backend/Logic/Logic/OfficeBookingLogic.cs
+++ b/backend/absence_manager_backend/Logic/Logic/OfficeBookingLogic.cs
@@ -19,6 +19,7 @@ namespace Logic.Logic
         private readonly Repository<Location> _locationRepository;
         private readonly Repository<AppUser> _appUserRepository;
         private readonly DtoProvider _dtoProvider;
+        private readonly IUserActivityLogger _activityLogger;
 
         public OfficeBookingLogic(
             Repository<OfficeBooking> officeBookingRepository,
@@ -26,7 +27,9 @@ namespace Logic.Logic
             Repository<Office> officeRepository,
             Repository<Location> locationRepository,
             Repository<AppUser> appUserRepository,
-            DtoProvider dtoProvider)
+            DtoProvider dtoProvider,
+            IUserActivityLogger activityLogger
+            )
         {
             _officeBookingRepository = officeBookingRepository;
             _workstationRepository = workstationRepository;
@@ -34,6 +37,7 @@ namespace Logic.Logic
             _locationRepository = locationRepository;
             _appUserRepository = appUserRepository;
             _dtoProvider = dtoProvider;
+            _activityLogger = activityLogger;
         }
 
         public OfficeDayAvailabilityDto GetOfficeDayAvailability(string officeId, DateOnly date, string currentUserId)
@@ -153,7 +157,7 @@ namespace Logic.Logic
         }
 
         //javitsd hogy a date formatumot is vizsgalja a create ha nem jo a formatum dobjon exceptiont
-        public OfficeBookingViewDto CreateBooking(CreateOfficeBookingDto dto, string currentUserId)
+        public async Task<OfficeBookingViewDto> CreateBookingAsync(CreateOfficeBookingDto dto, string currentUserId, CancellationToken cancellationToken = default)
         {
             ValidateBookingDate(dto.BookingDate);
 
@@ -212,9 +216,23 @@ namespace Logic.Logic
             if (createdBooking == null)
                 throw new InvalidOperationException("Created booking could not be loaded.");
 
-            Console.WriteLine($"Booking Id: {createdBooking.Id}");
-            Console.WriteLine($"WorkstationId: {createdBooking.WorkstationId}");
-            Console.WriteLine($"UserId: {createdBooking.UserId}");
+            await _activityLogger.LogAsync(
+                action: "OfficeBookingCreated",
+                entityType: "OfficeBooking",
+                entityId: createdBooking.Id,
+                actorUserId: currentUserId,
+                metadata: new
+                {
+                    createdBooking.BookingDate,
+                    createdBooking.WorkstationId,
+                    WorkstationName = createdBooking.Workstation.Name,
+                    WorkstationCode = createdBooking.Workstation.Code,
+                    OfficeId = createdBooking.Workstation.Office.Id,
+                    OfficeName = createdBooking.Workstation.Office.Name,
+                    LocationId = createdBooking.Workstation.Office.Location.Id,
+                    LocationName = createdBooking.Workstation.Office.Location.Name
+                },
+                cancellationToken: cancellationToken);
 
             return _dtoProvider.Mapper.Map<OfficeBookingViewDto>(createdBooking);
         }
@@ -240,10 +258,12 @@ namespace Logic.Logic
                 .Select(b => _dtoProvider.Mapper.Map<OfficeBookingViewDto>(b));
         }
 
-        public void CancelBooking(string bookingId, string currentUserId, bool isAdmin = false)
+        public async Task CancelBookingAsync(string bookingId, string currentUserId, bool isAdmin = false, CancellationToken cancellationToken = default)
         {
             var booking = _officeBookingRepository.GetAll()
                 .Include(b => b.Workstation)
+                .ThenInclude(w => w.Office)
+                .ThenInclude(o => o.Location)
                 .FirstOrDefault(b => b.Id == bookingId);
 
             if (booking == null)
@@ -253,7 +273,24 @@ namespace Logic.Logic
                 throw new InvalidOperationException("Booking is already cancelled.");
 
             if (!isAdmin && booking.UserId != currentUserId)
+            {
+                await _activityLogger.LogAsync(
+                    action: "UnauthorizedActionAttempt",
+                    entityType: "OfficeBooking",
+                    entityId: bookingId,
+                    actorUserId: currentUserId,
+                    metadata: new
+                    {
+                        AttemptedAction = "CancelOfficeBooking",
+                        BookingOwnerUserId = booking.UserId,
+                        booking.BookingDate,
+                        booking.WorkstationId
+                    },
+                    outcome: UserActivityLogOutcomes.Forbidden,
+                    cancellationToken: cancellationToken);
+
                 throw new UnauthorizedAccessException("You can only cancel your own booking.");
+            }
 
             var today = DateOnly.FromDateTime(DateTime.Today);
 
@@ -265,6 +302,25 @@ namespace Logic.Logic
             booking.CancelledByUserId = currentUserId;
 
             _officeBookingRepository.Update(booking);
+
+            await _activityLogger.LogAsync(
+                action: "OfficeBookingCancelled",
+                entityType: "OfficeBooking",
+                entityId: booking.Id,
+                actorUserId: currentUserId,
+                metadata: new
+                {
+                    booking.BookingDate,
+                    booking.WorkstationId,
+                    WorkstationName = booking.Workstation.Name,
+                    WorkstationCode = booking.Workstation.Code,
+                    OfficeId = booking.Workstation.Office.Id,
+                    OfficeName = booking.Workstation.Office.Name,
+                    LocationId = booking.Workstation.Office.Location.Id,
+                    LocationName = booking.Workstation.Office.Location.Name,
+                    IsAdminCancellation = isAdmin
+                },
+                cancellationToken: cancellationToken);
         }
 
         private static void ValidateBookingDate(DateOnly bookingDate)

--- a/backend/absence_manager_backend/Logic/Logic/OfficeBookingLogic.cs
+++ b/backend/absence_manager_backend/Logic/Logic/OfficeBookingLogic.cs
@@ -217,8 +217,8 @@ namespace Logic.Logic
                 throw new InvalidOperationException("Created booking could not be loaded.");
 
             await _activityLogger.LogAsync(
-                action: "OfficeBookingCreated",
-                entityType: "OfficeBooking",
+                action: UserActivityLogActions.OfficeBookingCreated,
+                entityType: UserActivityLogEntityTypes.OfficeBooking,
                 entityId: createdBooking.Id,
                 actorUserId: currentUserId,
                 metadata: new
@@ -275,8 +275,8 @@ namespace Logic.Logic
             if (!isAdmin && booking.UserId != currentUserId)
             {
                 await _activityLogger.LogAsync(
-                    action: "UnauthorizedActionAttempt",
-                    entityType: "OfficeBooking",
+                    action: UserActivityLogActions.UnauthorizedActionAttempt,
+                    entityType: UserActivityLogEntityTypes.OfficeBooking,
                     entityId: bookingId,
                     actorUserId: currentUserId,
                     metadata: new
@@ -304,8 +304,8 @@ namespace Logic.Logic
             _officeBookingRepository.Update(booking);
 
             await _activityLogger.LogAsync(
-                action: "OfficeBookingCancelled",
-                entityType: "OfficeBooking",
+                action: UserActivityLogActions.OfficeBookingCancelled,
+                entityType: UserActivityLogEntityTypes.OfficeBooking,
                 entityId: booking.Id,
                 actorUserId: currentUserId,
                 metadata: new

--- a/backend/absence_manager_backend/absence_manager_backend/Controllers/OfficeBookingsController .cs
+++ b/backend/absence_manager_backend/absence_manager_backend/Controllers/OfficeBookingsController .cs
@@ -103,7 +103,7 @@ namespace Absence_Manager.Controllers
             try
             {
                 var currentUserId = await _currentUserService.GetUserIdAsync(cancellationToken);
-                var result = _officeBookingLogic.CreateBooking(dto, currentUserId);
+                var result = await _officeBookingLogic.CreateBookingAsync(dto, currentUserId, cancellationToken);
                 return Ok(result);
             }
             catch (UnauthorizedAccessException ex)
@@ -132,7 +132,11 @@ namespace Absence_Manager.Controllers
             try
             {
                 var currentUserId = await _currentUserService.GetUserIdAsync(cancellationToken);
-                _officeBookingLogic.CancelBooking(bookingId, currentUserId, isAdmin: false);
+                await _officeBookingLogic.CancelBookingAsync(
+                    bookingId,
+                    currentUserId,
+                    isAdmin: false,
+                    cancellationToken);
                 return NoContent();
             }
             catch (KeyNotFoundException ex)

--- a/backend/absence_manager_backend/absence_manager_backend/Controllers/UserActivityLogsController.cs
+++ b/backend/absence_manager_backend/absence_manager_backend/Controllers/UserActivityLogsController.cs
@@ -1,0 +1,223 @@
+﻿using Data;
+using Entities.Dtos.UserActivityLogDtos;
+using Logic.Helper;
+using Logic.Logic;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Identity.Web.Resource;
+
+namespace Absence_Manager.Controllers
+{
+    [ApiController]
+    [Route("api/user-activity-logs")]
+    [Authorize]
+    [RequiredScope("user_impersonation")]
+    public class UserActivityLogsController : ControllerBase
+    {
+        private const int DefaultPageSize = 50;
+        private const int MaximumPageSize = 200;
+
+        private readonly AbsenceManagerDbContext _dbContext;
+        private readonly ICurrentUserService _currentUserService;
+
+        public UserActivityLogsController(AbsenceManagerDbContext dbContext, ICurrentUserService currentUserService)
+        {
+            _dbContext = dbContext;
+            _currentUserService = currentUserService;
+        }
+
+        [HttpGet]
+        public async Task<IActionResult> GetLogs(
+            [FromQuery] DateTime? fromUtc,
+            [FromQuery] DateTime? toUtc,
+            [FromQuery] string? actorUserId,
+            [FromQuery] string? action,
+            [FromQuery] string? entityType,
+            [FromQuery] string? entityId,
+            [FromQuery] string? outcome,
+            [FromQuery] int page = 1,
+            [FromQuery] int pageSize = DefaultPageSize,
+            CancellationToken cancellationToken = default)
+        {
+            try
+            {
+                var currentUser = await GetCurrentUserAsync(cancellationToken);
+                var canSeeAllLogs = AbsenceRequestLogic.IsHrOrAdmin(currentUser);
+
+                page = Math.Max(page, 1);
+                pageSize = Math.Clamp(pageSize, 1, MaximumPageSize);
+
+                var query =
+                    from log in _dbContext.UserActivityLogs.AsNoTracking()
+                    join user in _dbContext.AppUsers.AsNoTracking()
+                        on log.ActorUserId equals user.Id into userJoin
+                    from actor in userJoin.DefaultIfEmpty()
+                    select new
+                    {
+                        Log = log,
+                        Actor = actor
+                    };
+
+                if (!canSeeAllLogs)
+                {
+                    query = query.Where(x => x.Log.ActorUserId == currentUser.Id);
+                }
+                else if (!string.IsNullOrWhiteSpace(actorUserId))
+                {
+                    query = query.Where(x => x.Log.ActorUserId == actorUserId);
+                }
+
+                if (fromUtc.HasValue)
+                {
+                    query = query.Where(x => x.Log.CreatedAtUtc >= fromUtc.Value);
+                }
+
+                if (toUtc.HasValue)
+                {
+                    query = query.Where(x => x.Log.CreatedAtUtc <= toUtc.Value);
+                }
+
+                if (!string.IsNullOrWhiteSpace(action))
+                {
+                    query = query.Where(x => x.Log.Action == action);
+                }
+
+                if (!string.IsNullOrWhiteSpace(entityType))
+                {
+                    query = query.Where(x => x.Log.EntityType == entityType);
+                }
+
+                if (!string.IsNullOrWhiteSpace(entityId))
+                {
+                    query = query.Where(x => x.Log.EntityId == entityId);
+                }
+
+                if (!string.IsNullOrWhiteSpace(outcome))
+                {
+                    query = query.Where(x => x.Log.Outcome == outcome);
+                }
+
+                var totalCount = await query.CountAsync(cancellationToken);
+
+                var items = await query
+                    .OrderByDescending(x => x.Log.CreatedAtUtc)
+                    .Skip((page - 1) * pageSize)
+                    .Take(pageSize)
+                    .Select(x => new UserActivityLogViewDto
+                    {
+                        Id = x.Log.Id,
+                        CreatedAtUtc = x.Log.CreatedAtUtc,
+                        ActorUserId = x.Log.ActorUserId,
+                        ActorDisplayName = x.Actor != null ? x.Actor.DisplayName : null,
+                        ActorEmail = x.Actor != null ? x.Actor.Email : null,
+                        ActorEntraObjectId = x.Log.ActorEntraObjectId,
+                        TenantId = x.Log.TenantId,
+                        Action = x.Log.Action,
+                        EntityType = x.Log.EntityType,
+                        EntityId = x.Log.EntityId,
+                        Outcome = x.Log.Outcome,
+                        IpAddress = x.Log.IpAddress,
+                        UserAgent = x.Log.UserAgent,
+                        RequestMethod = x.Log.RequestMethod,
+                        RequestPath = x.Log.RequestPath,
+                        CorrelationId = x.Log.CorrelationId,
+                        MetadataJson = x.Log.MetadataJson
+                    })
+                    .ToListAsync(cancellationToken);
+
+                return Ok(new UserActivityLogListResultDto
+                {
+                    Page = page,
+                    PageSize = pageSize,
+                    TotalCount = totalCount,
+                    Items = items
+                });
+            }
+            catch (UnauthorizedAccessException ex)
+            {
+                return Unauthorized(new { message = ex.Message });
+            }
+            catch (KeyNotFoundException ex)
+            {
+                return NotFound(new { message = ex.Message });
+            }
+            catch (OperationCanceledException)
+            {
+                return new StatusCodeResult(499);
+            }
+        }
+
+        [HttpGet("{id}")]
+        public async Task<IActionResult> GetLogById(string id, CancellationToken cancellationToken)
+        {
+            try
+            {
+                var currentUser = await GetCurrentUserAsync(cancellationToken);
+                var canSeeAllLogs = AbsenceRequestLogic.IsHrOrAdmin(currentUser);
+
+                var result = await (
+                    from log in _dbContext.UserActivityLogs.AsNoTracking()
+                    join user in _dbContext.AppUsers.AsNoTracking()
+                        on log.ActorUserId equals user.Id into userJoin
+                    from actor in userJoin.DefaultIfEmpty()
+                    where log.Id == id
+                    select new UserActivityLogViewDto
+                    {
+                        Id = log.Id,
+                        CreatedAtUtc = log.CreatedAtUtc,
+                        ActorUserId = log.ActorUserId,
+                        ActorDisplayName = actor != null ? actor.DisplayName : null,
+                        ActorEmail = actor != null ? actor.Email : null,
+                        ActorEntraObjectId = log.ActorEntraObjectId,
+                        TenantId = log.TenantId,
+                        Action = log.Action,
+                        EntityType = log.EntityType,
+                        EntityId = log.EntityId,
+                        Outcome = log.Outcome,
+                        IpAddress = log.IpAddress,
+                        UserAgent = log.UserAgent,
+                        RequestMethod = log.RequestMethod,
+                        RequestPath = log.RequestPath,
+                        CorrelationId = log.CorrelationId,
+                        MetadataJson = log.MetadataJson
+                    })
+                    .FirstOrDefaultAsync(cancellationToken);
+
+                if (result == null)
+                {
+                    return NotFound(new { message = "User activity log not found." });
+                }
+
+                if (!canSeeAllLogs && result.ActorUserId != currentUser.Id)
+                {
+                    return Forbid();
+                }
+
+                return Ok(result);
+            }
+            catch (UnauthorizedAccessException ex)
+            {
+                return Unauthorized(new { message = ex.Message });
+            }
+            catch (KeyNotFoundException ex)
+            {
+                return NotFound(new { message = ex.Message });
+            }
+            catch (OperationCanceledException)
+            {
+                return new StatusCodeResult(499);
+            }
+        }
+
+        private async Task<Entities.Models.AppUser> GetCurrentUserAsync(CancellationToken cancellationToken)
+        {
+            var currentUserId = await _currentUserService.GetUserIdAsync(cancellationToken);
+
+            return await _dbContext.AppUsers
+                .AsNoTracking()
+                .FirstOrDefaultAsync(x => x.Id == currentUserId, cancellationToken)
+                ?? throw new KeyNotFoundException("Current user not found.");
+        }
+    }
+}

--- a/backend/absence_manager_backend/absence_manager_backend/Controllers/UserActivityLogsController.cs
+++ b/backend/absence_manager_backend/absence_manager_backend/Controllers/UserActivityLogsController.cs
@@ -27,6 +27,102 @@ namespace Absence_Manager.Controllers
             _currentUserService = currentUserService;
         }
 
+        [HttpGet("filter-options")]
+        public IActionResult GetFilterOptions()
+        {
+            var result = new UserActivityLogFilterOptionsDto
+            {
+                Actions = new[]
+                {
+            new UserActivityLogOptionDto
+            {
+                Value = UserActivityLogActions.OfficeBookingCreated,
+                Label = "Foglalás létrehozása"
+            },
+            new UserActivityLogOptionDto
+            {
+                Value = UserActivityLogActions.OfficeBookingCancelled,
+                Label = "Foglalás lemondása"
+            },
+            new UserActivityLogOptionDto
+            {
+                Value = UserActivityLogActions.AbsenceRequestCreated,
+                Label = "Távolléti kérelem létrehozása"
+            },
+            new UserActivityLogOptionDto
+            {
+                Value = UserActivityLogActions.AbsenceRequestCancelled,
+                Label = "Távolléti kérelem visszavonása"
+            },
+            new UserActivityLogOptionDto
+            {
+                Value = UserActivityLogActions.AbsenceRequestApproved,
+                Label = "Távolléti kérelem jóváhagyása"
+            },
+            new UserActivityLogOptionDto
+            {
+                Value = UserActivityLogActions.AbsenceRequestRejected,
+                Label = "Távolléti kérelem elutasítása"
+            },
+            new UserActivityLogOptionDto
+            {
+                Value = UserActivityLogActions.UserGraphSyncCompleted,
+                Label = "Felhasználói Graph szinkron sikeres"
+            },
+            new UserActivityLogOptionDto
+            {
+                Value = UserActivityLogActions.UserGraphSyncFailed,
+                Label = "Felhasználói Graph szinkron sikertelen"
+            },
+            new UserActivityLogOptionDto
+            {
+                Value = UserActivityLogActions.UnauthorizedActionAttempt,
+                Label = "Jogosulatlan műveletkísérlet"
+            }
+        },
+
+                EntityTypes = new[]
+                {
+            new UserActivityLogOptionDto
+            {
+                Value = UserActivityLogEntityTypes.OfficeBooking,
+                Label = "Munkaállomás foglalás"
+            },
+            new UserActivityLogOptionDto
+            {
+                Value = UserActivityLogEntityTypes.AbsenceRequest,
+                Label = "Távolléti kérelem"
+            },
+            new UserActivityLogOptionDto
+            {
+                Value = UserActivityLogEntityTypes.AppUser,
+                Label = "Felhasználó"
+            }
+        },
+
+                Outcomes = new[]
+                {
+            new UserActivityLogOptionDto
+            {
+                Value = UserActivityLogOutcomes.Success,
+                Label = "Sikeres"
+            },
+            new UserActivityLogOptionDto
+            {
+                Value = UserActivityLogOutcomes.Failed,
+                Label = "Sikertelen"
+            },
+            new UserActivityLogOptionDto
+            {
+                Value = UserActivityLogOutcomes.Forbidden,
+                Label = "Tiltott"
+            }
+        }
+            };
+
+            return Ok(result);
+        }
+
         [HttpGet]
         public async Task<IActionResult> GetLogs(
             [FromQuery] DateTime? fromUtc,

--- a/backend/absence_manager_backend/absence_manager_backend/Program.cs
+++ b/backend/absence_manager_backend/absence_manager_backend/Program.cs
@@ -22,6 +22,7 @@ builder.Services.AddScoped<IAppUserResolver, AppUserResolver>();
 builder.Services.AddScoped<IMsGraphLogic, MsGraphLogic>();
 builder.Services.AddScoped<ICurrentUserService, CurrentUserService>();
 builder.Services.AddScoped<ICurrentUserGraphSyncService, CurrentUserGraphSyncService>();
+builder.Services.AddScoped<IUserActivityLogger, UserActivityLogger>();
 
 var allowedOrigins = builder.Configuration.GetSection("Cors:AllowedOrigins").Get<string[]>();
 


### PR DESCRIPTION
## Summary

This PR introduces backend support for user activity audit logging. The goal is to make important user actions traceable in the application, including office bookings, absence requests, and Microsoft Graph user synchronization.

The implementation adds a dedicated audit log table, a reusable activity logging service, backend query endpoints, and predefined filter options for future frontend integration.

## Scope

Included in this PR:

- Added `UserActivityLog` entity and database mapping.
- Added audit log persistence through `IUserActivityLogger`.
- Added audit logging for office booking actions.
- Added audit logging for absence request actions.
- Added audit logging for Graph user synchronization.
- Added backend endpoints for querying audit logs.
- Added filter option endpoint for audit log actions, entity types, and outcomes.
- Centralized audit log action, entity type, and outcome constants.

Not included in this PR:

- Frontend audit log page.
- Advanced role/permission management.
- Admin UI for audit log filtering.
- Long-term retention or archival rules.

These should be handled in separate follow-up issues.

## Logged Activities

The following user activities are now logged:

- Office booking created
- Office booking cancelled
- Unauthorized office booking cancellation attempt
- Absence request created
- Absence request cancelled
- Absence request approved
- Absence request rejected
- Unauthorized absence request action attempt
- User Graph sync completed
- User Graph sync failed

## Backend Endpoints

### Query audit logs

```http
GET /api/user-activity-logs
```

Supports filtering by:

- `fromUtc`
- `toUtc`
- `actorUserId`
- `action`
- `entityType`
- `entityId`
- `outcome`
- `page`
- `pageSize`

### Get audit log by ID

```http
GET /api/user-activity-logs/{id}
```

### Get filter options

```http
GET /api/user-activity-logs/filter-options
```

Returns available action, entity type, and outcome options for future frontend dropdown filters.

## Security and Data Handling

The audit log intentionally avoids storing sensitive data such as:

- Access tokens
- Raw request bodies
- Full claim dumps
- Full absence request reasons
- Full decision comments

For sensitive text fields, the audit metadata only stores whether a value was provided, for example `HasReason` or `HasDecisionComment`.

## Access Behavior

Current backend behavior:

- HR/Admin-like users can query all audit logs.
- Regular users can only query their own audit logs.

This is based on the existing user role/title logic. A more complete permission model should be implemented separately before adding the frontend audit log page.

## Database Changes

A new table is added:

```text
UserActivityLogs
```

The table stores:

- Actor user information
- Action name
- Entity type and entity ID
- Outcome
- Request metadata
- Correlation ID
- Optional structured metadata as JSON
- Creation timestamp

## Testing Notes

Recommended manual checks:

1. Create an office booking and verify `OfficeBookingCreated` is written.
2. Cancel an office booking and verify `OfficeBookingCancelled` is written.
3. Create an absence request and verify `AbsenceRequestCreated` is written.
4. Approve or reject an absence request and verify the correct action is written.
5. Run Graph sync and verify either `UserGraphSyncCompleted` or `UserGraphSyncFailed` is written.
6. Query `GET /api/user-activity-logs` and verify pagination and filters.
7. Query `GET /api/user-activity-logs/filter-options` and verify dropdown option values.

## Follow-up Work

Suggested follow-up issues:

- Implement proper role and permission management.
- Add frontend audit log page after permission handling is finalized.
- Add audit log retention policy.
- Add export functionality if business users need reports.