### PR TITLE
Display Manager and Direct Reports on Profile Page

### DIFF
--- a/frontend/absence_manager_frontend/src/app/components/profile/profile.html
+++ b/frontend/absence_manager_frontend/src/app/components/profile/profile.html
@@ -45,7 +45,12 @@
     <span>{{ error }}</span>
   </div>
 
-  <section class="user-card" *ngIf="userProfile">
+  <div class="profile-alert profile-alert--danger" *ngIf="hierarchyError">
+    <i class="bi bi-exclamation-triangle-fill"></i>
+    <span>{{ hierarchyError }}</span>
+  </div>
+
+  <section class="user-card user-card--with-manager" *ngIf="userProfile">
     <div class="user-card__avatar">
       {{ getInitials(userProfile.displayName) }}
     </div>
@@ -71,6 +76,36 @@
         </span>
       </div>
     </div>
+
+    <aside class="user-card__manager">
+      <div class="manager-inline-card__icon">
+        <i class="bi bi-diagram-3"></i>
+      </div>
+
+      <div class="manager-inline-card__content">
+        <span class="manager-inline-card__label">Manager</span>
+
+        <strong *ngIf="hierarchyLoading">
+          Betöltés...
+        </strong>
+
+        <ng-container *ngIf="!hierarchyLoading">
+          <strong *ngIf="manager; else noManagerInline">
+            {{ getUserDisplayName(manager) }}
+          </strong>
+
+          <span class="manager-inline-card__email" *ngIf="manager && getUserEmail(manager)">
+            {{ getUserEmail(manager) }}
+          </span>
+
+          <ng-template #noManagerInline>
+            <strong class="manager-inline-card__muted">
+              Nincs aktív manager kapcsolat.
+            </strong>
+          </ng-template>
+        </ng-container>
+      </div>
+    </aside>
   </section>
 
   <section class="additional-data-card" *ngIf="userProfile">
@@ -116,6 +151,43 @@
         <div class="data-row__content">
           <p class="data-label">Email</p>
           <p class="data-value">{{ userProfile.email || '-' }}</p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="additional-data-card" *ngIf="userProfile && !hierarchyLoading && hasDirectReports">
+    <div class="section-header">
+      <div>
+        <span class="section-eyebrow">
+          <i class="bi bi-people"></i>
+          Manager nézet
+        </span>
+
+        <h2>Közvetlen beosztottak</h2>
+      </div>
+
+      <span class="profile-badge">
+        <i class="bi bi-person-lines-fill"></i>
+        {{ directReports.length }} fő
+      </span>
+    </div>
+
+    <div class="profile-data-grid">
+      <div class="data-row" *ngFor="let directReport of directReports; trackBy: trackByUser">
+        <div class="data-row__icon">
+          <i class="bi bi-person"></i>
+        </div>
+
+        <div class="data-row__content">
+          <p class="data-label">Beosztott</p>
+          <p class="data-value">{{ getUserDisplayName(directReport) }}</p>
+          <p class="data-subvalue" *ngIf="getUserEmail(directReport)">
+            {{ getUserEmail(directReport) }}
+          </p>
+          <p class="data-subvalue">
+            {{ getUserDetails(directReport) }}
+          </p>
         </div>
       </div>
     </div>

--- a/frontend/absence_manager_frontend/src/app/components/profile/profile.sass
+++ b/frontend/absence_manager_frontend/src/app/components/profile/profile.sass
@@ -218,6 +218,7 @@
     font-weight: 600
 
 .additional-data-card
+    margin-top: .75rem
     padding: 1.2rem
     border-radius: 22px
     background: linear-gradient(135deg, #fff, rgba(0, 146, 123, .035))
@@ -279,6 +280,12 @@
     font-weight: 500
     line-height: 1.35
     overflow-wrap: anywhere
+
+.data-subvalue
+    margin: 0.15rem 0 0
+    color: var(--phx-muted)
+    font-size: 0.875rem
+    word-break: break-word
 
 .profile-alert
     display: flex
@@ -388,3 +395,72 @@
 
     .data-row
         padding: .85rem
+
+.user-card--with-manager
+    display: grid
+    grid-template-columns: auto 1fr auto
+    align-items: center
+    gap: 1.25rem
+
+.user-card__manager
+    min-width: 230px
+    max-width: 300px
+    display: flex
+    align-items: center
+    gap: 0.75rem
+    padding: 0.9rem 1rem
+    border-radius: 16px
+    background: var(--phx-bg)
+    border: 1px solid var(--phx-border)
+
+.manager-inline-card__icon
+    width: 38px
+    height: 38px
+    flex: 0 0 38px
+    display: flex
+    align-items: center
+    justify-content: center
+    border-radius: 12px
+    background: rgba(0, 146, 123, .1)
+    color: var(--phx-green)
+
+.manager-inline-card__content
+    min-width: 0
+    display: flex
+    flex-direction: column
+    gap: 0.15rem
+
+.manager-inline-card__label
+    font-size: 0.72rem
+    font-weight: 700
+    text-transform: uppercase
+    letter-spacing: 0.06em
+    color: var(--phx-muted)
+
+.manager-inline-card__content strong
+    color: var(--phx-text)
+    font-size: 0.95rem
+    line-height: 1.2
+    white-space: nowrap
+    overflow: hidden
+    text-overflow: ellipsis
+
+.manager-inline-card__email
+    color: var(--phx-muted)
+    font-size: 0.8rem
+    white-space: nowrap
+    overflow: hidden
+    text-overflow: ellipsis
+
+.manager-inline-card__muted
+    color: var(--phx-muted) !important
+    font-weight: 500
+
+@media (max-width: 900px)
+    .user-card--with-manager
+        grid-template-columns: auto 1fr
+
+    .user-card__manager
+        grid-column: 1 / -1
+        max-width: none
+        width: 100%

--- a/frontend/absence_manager_frontend/src/app/components/profile/profile.ts
+++ b/frontend/absence_manager_frontend/src/app/components/profile/profile.ts
@@ -1,9 +1,11 @@
 import { ChangeDetectorRef, Component, OnDestroy, OnInit } from '@angular/core';
-import { UserService } from '../../services/user.service';
+import { AppUserHierarchyDto, GraphAppUserDto, UserService } from '../../services/user.service';
 import { UserProfile } from '../../models/app-user-models';
 import { AuthService } from '../../auth/auth-service';
 import { takeUntil } from 'rxjs/internal/operators/takeUntil';
 import { Subject } from 'rxjs/internal/Subject';
+import { AccountInfo } from '@azure/msal-browser';
+import { finalize } from 'rxjs/internal/operators/finalize';
 
 @Component({
   selector: 'app-profile',
@@ -13,8 +15,15 @@ import { Subject } from 'rxjs/internal/Subject';
 })
 export class Profile implements OnInit, OnDestroy {
   userProfile: UserProfile | null = null;
+
+  manager: GraphAppUserDto | null = null;
+  directReports: GraphAppUserDto[] = [];
+
   loading = true;
+  hierarchyLoading = true;
+
   error: string | null = null;
+  hierarchyError: string | null = null;
 
   private readonly destroy$ = new Subject<void>();
 
@@ -30,32 +39,14 @@ export class Profile implements OnInit, OnDestroy {
     if (!account) {
       this.error = 'Nincs bejelentkezett felhasználó.';
       this.loading = false;
+      this.hierarchyLoading = false;
       return;
     }
 
-    this.userProfile = {
-      displayName: account.name || account.username || 'Ismeretlen felhasználó',
-      email: account.username || '',
-      department: '',
-      jobTitle: ''
-    };
+    this.userProfile = this.createProfileFromAccount(account);
 
-    this.userService.getMe()
-      .pipe(takeUntil(this.destroy$))
-      .subscribe({
-        next: profile => {
-          this.userProfile = profile;
-          this.loading = false;
-          this.error = null;
-          this.cdr.detectChanges();
-        },
-        error: err => {
-          console.error(err);
-          this.error = 'Hiba a profil betöltése közben.';
-          this.loading = false;
-          this.cdr.detectChanges();
-        }
-      });
+    this.loadProfile();
+    this.loadHierarchy();
   }
 
   ngOnDestroy(): void {
@@ -63,16 +54,117 @@ export class Profile implements OnInit, OnDestroy {
     this.destroy$.complete();
   }
 
-  getInitials(displayName: string): string {
-    return displayName
+  get hasDirectReports(): boolean {
+    return this.directReports.length > 0;
+  }
+
+  getInitials(displayName: string | null | undefined): string {
+    const initials = (displayName || '')
       .split(' ')
       .filter(Boolean)
-      .map(n => n[0])
+      .map(name => name[0])
       .join('')
-      .toUpperCase();
+      .toUpperCase()
+      .slice(0, 2);
+
+    return initials || '?';
+  }
+
+  getUserDisplayName(user: GraphAppUserDto | null | undefined): string {
+    return user?.displayName
+      || user?.email
+      || user?.userPrincipalName
+      || 'Ismeretlen felhasználó';
+  }
+
+  getUserEmail(user: GraphAppUserDto | null | undefined): string {
+    return user?.email || user?.userPrincipalName || '';
+  }
+
+  getUserDetails(user: GraphAppUserDto | null | undefined): string {
+    const details = [
+      user?.jobTitle,
+      user?.department
+    ].filter(Boolean);
+
+    return details.length ? details.join(' · ') : 'Nincs szervezeti adat';
+  }
+
+  trackByUser(_: number, user: GraphAppUserDto): string {
+    return user.appUserId || user.entraObjectId || this.getUserDisplayName(user);
   }
 
   async logout(): Promise<void> {
     await this.authService.logout();
+  }
+
+  private loadProfile(): void {
+    this.loading = true;
+    this.error = null;
+
+    this.userService.getMe()
+      .pipe(
+        takeUntil(this.destroy$),
+        finalize(() => {
+          this.loading = false;
+          this.cdr.detectChanges();
+        })
+      )
+      .subscribe({
+        next: profile => {
+          this.userProfile = profile;
+        },
+        error: err => {
+          console.error(err);
+          this.error = 'Hiba a profil betöltése közben.';
+        }
+      });
+  }
+
+  private loadHierarchy(): void {
+    this.hierarchyLoading = true;
+    this.hierarchyError = null;
+
+    this.userService.getMyHierarchy()
+      .pipe(
+        takeUntil(this.destroy$),
+        finalize(() => {
+          this.hierarchyLoading = false;
+          this.cdr.detectChanges();
+        })
+      )
+      .subscribe({
+        next: hierarchy => {
+          this.applyHierarchy(hierarchy);
+        },
+        error: err => {
+          console.error(err);
+          this.manager = null;
+          this.directReports = [];
+          this.hierarchyError = 'Hiba a vezetői kapcsolatok betöltése közben.';
+        }
+      });
+  }
+
+  private applyHierarchy(hierarchy: AppUserHierarchyDto): void {
+    this.manager = hierarchy.manager ?? null;
+
+    this.directReports = (hierarchy.directReports ?? [])
+      .filter(user => user.isActiveLocalUser)
+      .sort((a, b) =>
+        this.getUserDisplayName(a).localeCompare(
+          this.getUserDisplayName(b),
+          'hu'
+        )
+      );
+  }
+
+  private createProfileFromAccount(account: AccountInfo): UserProfile {
+    return {
+      displayName: account.name || account.username || 'Ismeretlen felhasználó',
+      email: account.username || '',
+      department: '',
+      jobTitle: ''
+    };
   }
 }

--- a/frontend/absence_manager_frontend/src/app/services/user.service.ts
+++ b/frontend/absence_manager_frontend/src/app/services/user.service.ts
@@ -58,6 +58,12 @@ export class UserService {
     );
   }
 
+  getMyHierarchy(): Observable<AppUserHierarchyDto> {
+    return this.http.get<AppUserHierarchyDto>(
+      `${this.configService.apiUrl}/users/me/hierarchy`
+    );
+  }
+
   syncCurrentUserFromGraph(): Observable<UserContextDto> {
     return this.http.post<UserContextDto>(
       `${this.configService.apiUrl}/users/me/sync-from-graph`,


### PR DESCRIPTION
## Summary

This PR extends the user profile page with organization hierarchy information.

The profile page now shows the logged-in user's direct manager in the main personal information card. If the user is a manager and has active direct reports, a separate direct reports section is displayed below the profile details.

## Changes

### Frontend

- Added hierarchy loading to the profile page.
- Integrated the existing `GET /api/users/me/hierarchy` endpoint through `UserService`.
- Added support models for hierarchy data:
  - `GraphAppUserDto`
  - `AppUserHierarchyDto`
  - `UserContextDto`
- Displayed the current user's manager inside the main profile card, aligned to the right side of the panel.
- Displayed direct reports only when the current user has at least one active direct report.
- Added helper methods for user display values:
  - display name fallback
  - email / UPN fallback
  - job title and department formatting
  - direct report `trackBy` handling
- Added loading and error handling for hierarchy data.
- Updated profile styling using the existing project color variables and CSS custom properties.

### UI behavior

- Every user can see their own manager on the profile page.
- If no active manager relation exists, a muted fallback text is shown.
- The direct reports panel is only rendered when there are active direct reports.
- Users without direct reports do not see an empty direct reports panel.
- The manager display is intentionally compact and shown as part of the personal data card instead of a separate large section.
- On smaller screens, the manager card moves below the main profile data to keep the layout readable.

## Backend

No backend changes were required.

The implementation uses the already available authenticated endpoint:

```http
GET /api/users/me/hierarchy
```

The endpoint returns the current user's hierarchy information from the local database, including:

- current user
- manager
- direct reports

## Expected Result

After this change:

- The profile page displays the logged-in user's manager.
- Managers can see their active direct reports.
- Non-manager users do not see an empty direct reports section.
- The UI remains consistent with the existing profile page design.
- Styling uses the existing PHOENIX color variables instead of introducing unrelated hardcoded colors.

## Testing Notes

Recommended checks:

1. Log in with a user who has an active manager relation.
   - The manager should be visible in the main profile card.

2. Log in with a user who has no active manager relation.
   - The profile should show a muted fallback message for the manager.

3. Log in with a manager user who has active direct reports.
   - The direct reports panel should appear and list the active direct reports.

4. Log in with a non-manager user.
   - The direct reports panel should not be rendered.

5. Verify responsive layout.
   - On desktop, the manager information should appear on the right side of the profile card.
   - On smaller screens, it should move below the main user data.

## Related Data Requirements

The displayed hierarchy depends on active rows in the `AppUserManagerRelations` table.

For the manager display:

```sql
"UserId" = current_user_id
AND "IsActive" = true
```

For the direct reports display:

```sql
"ManagerUserId" = current_user_id
AND "IsActive" = true
```
