### PR TITLE
Token flow fix

### DIFF
--- a/frontend/absence_manager_frontend/src/app/app.ts
+++ b/frontend/absence_manager_frontend/src/app/app.ts
@@ -40,7 +40,7 @@ export class App implements OnInit, OnDestroy {
           return;
         }
 
-        this.startGraphSync();
+        void this.startGraphSyncIfTokenAvailable();
       });
 
     this.updateRouteState();
@@ -61,13 +61,25 @@ export class App implements OnInit, OnDestroy {
   private async bootstrapAuth(): Promise<void> {
     try {
       await this.authService.bootstrap();
-
-      if (this.authService.isLoggedIn()) {
-        this.startGraphSync();
-      }
+      await this.startGraphSyncIfTokenAvailable();
     } catch (error) {
       console.error('Auth bootstrap failed in App.', error);
     }
+  }
+
+  private async startGraphSyncIfTokenAvailable(): Promise<void> {
+    if (this.graphSyncStarted) {
+      return;
+    }
+
+    const token = await this.authService.acquireApiToken();
+
+    if (!token) {
+      this.graphSyncStarted = false;
+      return;
+    }
+
+    this.startGraphSync();
   }
 
   private startGraphSync(): void {
@@ -82,6 +94,7 @@ export class App implements OnInit, OnDestroy {
       .subscribe({
         error: err => {
           console.warn('Graph szinkron sikertelen.', err);
+          this.graphSyncStarted = false;
         }
       });
   }

--- a/frontend/absence_manager_frontend/src/app/auth/auth-interceptor.ts
+++ b/frontend/absence_manager_frontend/src/app/auth/auth-interceptor.ts
@@ -21,11 +21,21 @@ export const authInterceptor: HttpInterceptorFn = (req, next) => {
     return next(req);
   }
 
+  const handleAuthFailure = (error: unknown) => {
+    return from(authService.clearSessionAfterAuthFailure()).pipe(
+      switchMap(() => {
+        router.navigate(['/welcome']);
+        return throwError(() => error);
+      })
+    );
+  };
+
   return from(authService.acquireApiToken()).pipe(
     switchMap(token => {
       if (!token) {
-        router.navigate(['/welcome']);
-        return throwError(() => new Error('Nincs hozzáférési token.'));
+        return handleAuthFailure(
+          new Error('Nincs érvényes hozzáférési token.')
+        );
       }
 
       const authReq = req.clone({
@@ -36,13 +46,18 @@ export const authInterceptor: HttpInterceptorFn = (req, next) => {
 
       return next(authReq).pipe(
         catchError((error: HttpErrorResponse) => {
-          if (error.status === 401 || error.status === 403) {
+          if (error.status === 401) {
+            return handleAuthFailure(error);
+          }
+
+          if (error.status === 403) {
             router.navigate(['/welcome']);
           }
 
           return throwError(() => error);
         })
       );
-    })
+    }),
+    catchError(error => handleAuthFailure(error))
   );
 };

--- a/frontend/absence_manager_frontend/src/app/auth/auth-service.ts
+++ b/frontend/absence_manager_frontend/src/app/auth/auth-service.ts
@@ -15,11 +15,11 @@ export type AuthProcessState =
 export class AuthService {
   private readonly accountSubject = new BehaviorSubject<AccountInfo | null>(null);
   private readonly tokenSubject = new BehaviorSubject<string | null>(null);
-
   private readonly authProcessStateSubject = new BehaviorSubject<AuthProcessState>('initializing');
 
   private initialized = false;
   private bootstrapPromise: Promise<void> | null = null;
+  private tokenRequestPromise: Promise<string | null> | null = null;
 
   readonly account$ = this.accountSubject.asObservable();
   readonly token$ = this.tokenSubject.asObservable();
@@ -54,34 +54,22 @@ export class AuthService {
   }
 
   async handleRedirect(): Promise<void> {
+    const msal = getMsalInstance();
+
     const authResult: AuthenticationResult | null =
-      await getMsalInstance().handleRedirectPromise();
+      await msal.handleRedirectPromise();
 
-    const accounts = getMsalInstance().getAllAccounts();
+    const account =
+      authResult?.account ??
+      msal.getActiveAccount() ??
+      msal.getAllAccounts()[0] ??
+      null;
 
-    if (authResult?.account) {
-      getMsalInstance().setActiveAccount(authResult.account);
-      this.accountSubject.next(authResult.account);
-      this.authProcessStateSubject.next('idle');
-      return;
+    if (account) {
+      msal.setActiveAccount(account);
     }
 
-    const activeAccount = getMsalInstance().getActiveAccount();
-
-    if (activeAccount) {
-      this.accountSubject.next(activeAccount);
-      this.authProcessStateSubject.next('idle');
-      return;
-    }
-
-    if (accounts.length > 0) {
-      getMsalInstance().setActiveAccount(accounts[0]);
-      this.accountSubject.next(accounts[0]);
-      this.authProcessStateSubject.next('idle');
-      return;
-    }
-
-    this.accountSubject.next(null);
+    this.accountSubject.next(account);
     this.tokenSubject.next(null);
     this.authProcessStateSubject.next('idle');
   }
@@ -91,6 +79,8 @@ export class AuthService {
 
     try {
       await this.initialize();
+
+      this.tokenSubject.next(null);
 
       await getMsalInstance().loginRedirect({
         scopes: ['openid', 'profile', 'email', getApiScope()]
@@ -108,9 +98,12 @@ export class AuthService {
       await this.initialize();
 
       this.tokenSubject.next(null);
+      this.accountSubject.next(null);
       this.bootstrapPromise = null;
+      this.tokenRequestPromise = null;
 
       await getMsalInstance().logoutRedirect({
+        account: this.getActiveAccount() ?? undefined,
         postLogoutRedirectUri: getPostLogoutRedirectUri()
       });
     } catch (error) {
@@ -122,14 +115,24 @@ export class AuthService {
   async acquireApiToken(): Promise<string | null> {
     await this.initialize();
 
-    const existingToken = this.tokenSubject.value;
-    if (existingToken) {
-      return existingToken;
+    if (this.tokenRequestPromise) {
+      return this.tokenRequestPromise;
     }
 
+    this.tokenRequestPromise = this.acquireApiTokenInternal()
+      .finally(() => {
+        this.tokenRequestPromise = null;
+      });
+
+    return this.tokenRequestPromise;
+  }
+
+  private async acquireApiTokenInternal(): Promise<string | null> {
     const account = this.getActiveAccount();
+
     if (!account) {
       this.tokenSubject.next(null);
+      this.accountSubject.next(null);
       return null;
     }
 
@@ -138,6 +141,13 @@ export class AuthService {
         account,
         scopes: [getApiScope()]
       });
+
+      if (result.account) {
+        getMsalInstance().setActiveAccount(result.account);
+        this.accountSubject.next(result.account);
+      } else {
+        this.accountSubject.next(account);
+      }
 
       this.tokenSubject.next(result.accessToken);
       return result.accessToken;
@@ -157,9 +167,18 @@ export class AuthService {
   }
 
   getActiveAccount(): AccountInfo | null {
-    return getMsalInstance().getActiveAccount()
-      ?? getMsalInstance().getAllAccounts()[0]
-      ?? null;
+    const msal = getMsalInstance();
+
+    const account =
+      msal.getActiveAccount() ??
+      msal.getAllAccounts()[0] ??
+      null;
+
+    if (account && !msal.getActiveAccount()) {
+      msal.setActiveAccount(account);
+    }
+
+    return account;
   }
 
   isLoggedIn(): boolean {

--- a/frontend/absence_manager_frontend/src/app/auth/auth-service.ts
+++ b/frontend/absence_manager_frontend/src/app/auth/auth-service.ts
@@ -16,6 +16,7 @@ export class AuthService {
   private readonly accountSubject = new BehaviorSubject<AccountInfo | null>(null);
   private readonly tokenSubject = new BehaviorSubject<string | null>(null);
   private readonly authProcessStateSubject = new BehaviorSubject<AuthProcessState>('initializing');
+  private authFailureCleanupPromise: Promise<void> | null = null;
 
   private initialized = false;
   private bootstrapPromise: Promise<void> | null = null;
@@ -183,5 +184,57 @@ export class AuthService {
 
   isLoggedIn(): boolean {
     return this.getActiveAccount() !== null || this.getAccount() !== null;
+  }
+
+  async clearSessionAfterAuthFailure(): Promise<void> {
+    if (this.authFailureCleanupPromise) {
+      return this.authFailureCleanupPromise;
+    }
+
+    this.authFailureCleanupPromise = this.clearSessionAfterAuthFailureInternal()
+      .finally(() => {
+        this.authFailureCleanupPromise = null;
+      });
+
+    return this.authFailureCleanupPromise;
+  }
+
+  private async clearSessionAfterAuthFailureInternal(): Promise<void> {
+    this.authProcessStateSubject.next('loggingOut');
+
+    try {
+      await this.initialize();
+
+      const msal = getMsalInstance();
+      const account = this.getActiveAccount();
+
+      this.accountSubject.next(null);
+      this.tokenSubject.next(null);
+      this.bootstrapPromise = null;
+      this.tokenRequestPromise = null;
+
+      await msal.logoutRedirect({
+        account: account ?? undefined,
+        postLogoutRedirectUri: getPostLogoutRedirectUri()
+      });
+
+      msal.setActiveAccount(null);
+
+      msal.setActiveAccount(null);
+    } catch (error) {
+      console.warn('Local auth cleanup failed.', error);
+
+      this.accountSubject.next(null);
+      this.tokenSubject.next(null);
+      this.bootstrapPromise = null;
+      this.tokenRequestPromise = null;
+
+      try {
+        getMsalInstance().setActiveAccount(null);
+      } catch {
+      }
+    } finally {
+      this.authProcessStateSubject.next('idle');
+    }
   }
 }

--- a/frontend/absence_manager_frontend/src/app/auth/guards/auth-guard.ts
+++ b/frontend/absence_manager_frontend/src/app/auth/guards/auth-guard.ts
@@ -8,12 +8,17 @@ export const authGuard: CanActivateFn = async () => {
 
   try {
     await authService.bootstrap();
-  } catch (error) {
-    console.error('Auth bootstrap failed', error);
-  }
 
-  if (authService.isLoggedIn()) {
-    return true;
+    const token = await authService.acquireApiToken();
+
+    if (token) {
+      return true;
+    }
+
+    await authService.clearSessionAfterAuthFailure();
+  } catch (error) {
+    console.error('Auth guard failed.', error);
+    await authService.clearSessionAfterAuthFailure();
   }
 
   return router.createUrlTree(['/welcome']);

--- a/frontend/absence_manager_frontend/src/app/auth/guards/guest-guard-guard.ts
+++ b/frontend/absence_manager_frontend/src/app/auth/guards/guest-guard-guard.ts
@@ -8,13 +8,22 @@ export const guestGuardGuard: CanActivateFn = async () => {
 
   try {
     await authService.bootstrap();
+
+    if (!authService.isLoggedIn()) {
+      return true;
+    }
+
+    const token = await authService.acquireApiToken();
+
+    if (token) {
+      return router.createUrlTree(['/desk-booking']);
+    }
+
+    await authService.clearSessionAfterAuthFailure();
+    return true;
   } catch (error) {
-    console.error('Guest guard bootstrap failed', error);
+    console.error('Guest guard failed.', error);
+    await authService.clearSessionAfterAuthFailure();
+    return true;
   }
-
-  if (authService.isLoggedIn()) {
-    return router.createUrlTree(['/desk-booking']);
-  }
-
-  return true;
 };

--- a/frontend/absence_manager_frontend/src/app/auth/guards/guest-guard-guard.ts
+++ b/frontend/absence_manager_frontend/src/app/auth/guards/guest-guard-guard.ts
@@ -8,22 +8,15 @@ export const guestGuardGuard: CanActivateFn = async () => {
 
   try {
     await authService.bootstrap();
-
-    if (!authService.isLoggedIn()) {
-      return true;
-    }
-
-    const token = await authService.acquireApiToken();
-
-    if (token) {
-      return router.createUrlTree(['/desk-booking']);
-    }
-
-    await authService.clearSessionAfterAuthFailure();
-    return true;
   } catch (error) {
-    console.error('Guest guard failed.', error);
+    console.error('Guest guard bootstrap failed', error);
     await authService.clearSessionAfterAuthFailure();
     return true;
   }
+
+  if (authService.isLoggedIn()) {
+    return router.createUrlTree(['/desk-booking']);
+  }
+
+  return true;
 };


### PR DESCRIPTION
## Summary

This pull request improves the stability of the Microsoft Entra ID / MSAL authentication flow in the frontend.

The main issue was that the application could keep using a previously acquired access token from its own in-memory state without checking whether the token was still valid. This could result in expired tokens being sent to the API, intermittent `401 Unauthorized` responses, and unstable navigation between protected pages and the welcome page.

The changes make token acquisition, route guarding, API authentication failure handling, and startup Graph synchronization more reliable.

## Changes

### Fixed stale access token reuse

The frontend no longer returns the previously stored access token directly from the local `tokenSubject`.

Instead, API token requests now always go through MSAL's silent token acquisition flow. This allows MSAL to validate the token state and refresh or reacquire a token when possible.

This prevents the application from reusing expired access tokens.

### Added token request deduplication

A shared `tokenRequestPromise` was added to avoid multiple simultaneous silent token acquisition calls when several API requests are triggered at the same time.

This reduces duplicate MSAL calls and helps avoid race conditions during application startup or page reloads.

### Improved API authentication failure handling

The HTTP auth interceptor now handles missing tokens and `401 Unauthorized` responses by clearing the frontend authentication state before redirecting the user to the welcome page.

The cleanup resets:

- the current account state,
- the cached token state,
- the bootstrap promise,
- the active token request promise,
- the active MSAL account.

`403 Forbidden` responses are not treated as automatic logout events, because they may represent a real authorization or permission issue rather than an expired session.

### Strengthened protected route validation

The protected route guard now verifies that a valid API token can be acquired before allowing access to protected pages.

Previously, the guard only checked whether an MSAL account was present. That was not sufficient, because a stale account entry could still exist even when the API token could no longer be acquired.

### Simplified guest route behavior

The guest guard was adjusted so the welcome page does not trigger unnecessary API token validation.

Protected pages remain strict and require an API token, while guest pages only perform a lightweight authentication state check.

This reduces login-related navigation loops and unnecessary token requests on the welcome page.

### Delayed Graph synchronization until API token is available

The application startup flow now starts the current user Graph synchronization only after a valid API token can be acquired.

This prevents `/users/me/sync-from-graph` from being called during invalid, expired, or incomplete authentication states.

### Removed unused authentication state module

The unused `auth.state.ts` module was removed to avoid confusion and prevent future usage of outdated authentication state handling.

The application now consistently uses `AuthService` as the single frontend authentication state source.

## Files changed

- `frontend/absence_manager_frontend/src/app/auth/auth-service.ts`
- `frontend/absence_manager_frontend/src/app/auth/auth-interceptor.ts`
- `frontend/absence_manager_frontend/src/app/auth/guards/auth-guard.ts`
- `frontend/absence_manager_frontend/src/app/auth/guards/guest-guard-guard.ts`
- `frontend/absence_manager_frontend/src/app/app.ts`
- `frontend/absence_manager_frontend/src/app/auth/auth.state.ts`

## Testing

The following checks should be performed:

1. Build the frontend successfully.

   ```bash
   npm run build
   ```

2. Log in with a valid Microsoft Entra ID user.

3. Open protected pages such as calendar, profile, absence requests, or approvals.

4. Verify that API requests include a valid bearer token.

5. Simulate an invalid or expired authentication state by clearing or corrupting browser auth cache entries.

6. Refresh a protected page.

7. Verify that the application redirects to the welcome page instead of entering a navigation loop.

8. Verify that the welcome page does not trigger unnecessary protected API calls.

9. Verify that Graph synchronization starts only after a valid API token is available.

10. Verify that normal logout still redirects the user through the Microsoft logout flow.

## Notes

The persistent SSO behavior was discussed separately but is not included in this pull request.

The MSAL cache storage strategy can be adjusted later depending on the desired balance between authentication stability and SharePoint-like persistent sign-in behavior.
